### PR TITLE
remove unnecessary nonce sanitization

### DIFF
--- a/inc/submissions/class-submissions-controller.php
+++ b/inc/submissions/class-submissions-controller.php
@@ -13,9 +13,9 @@ class AV_Petitioner_Submissions_Controller
      */
     public static function api_handle_form_submit()
     {
-        $wpnonce = !empty($_POST['nonce']) ? sanitize_text_field(wp_unslash($_POST['nonce'])) : '';
+        $wpnonce = !empty($_POST['nonce']) ? wp_unslash($_POST['nonce']) : '';
 
-        if (!isset($wpnonce) || !wp_verify_nonce($wpnonce, 'petitioner_form_nonce')) {
+        if (empty($wpnonce) || !wp_verify_nonce($wpnonce, 'petitioner_form_nonce')) {
             wp_send_json_error('Invalid nonce');
             wp_die();
         }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "petitioner",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "description": "A WordPress plugin for collecting petitions",
   "main": "index.js",
   "scripts": {

--- a/petitioner.php
+++ b/petitioner.php
@@ -5,7 +5,7 @@
  * Description:       A WordPress plugin for collecting petitions.
  * Requires at least: 5.9
  * Requires PHP:      8.0
- * Version:           0.3.3
+ * Version:           0.3.4
  * Author:            Anton Voytenko
  * License:           GPLv2 or later
  * License URI:       http://www.gnu.org/licenses/gpl-2.0.html

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link: https://avoy.me/
 Tags: petition, activism, form, community, email
 Requires at least: 5.9
 Tested up to: 6.8
-Stable Tag: 0.3.3
+Stable Tag: 0.3.4
 Requires PHP: 8.0
 License: GPLv2 or later 
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
@@ -81,6 +81,9 @@ You can find a more extensive FAQ [on the main website](https://getpetitioner.co
 6. Submissions
 
 == Changelog ==
+
+= 0.3.4 =
+* Bugfix: fix an occasional error related to unnecessary nonce sanitization
 
 = 0.3.3 =
 * Submissions tab improvements, special thanks to [@Shahraz98](https://github.com/Shahraz98)


### PR DESCRIPTION
## Description of change

Fix a bug in the submission logic preventing some users from signing the petition. In some cases, `sanitize_text_field` would change the nonce value so there would be a mismatch.
