### PR TITLE
Issue #135: [Bugfix] hide street addresses from gutenberg & frontend

### DIFF
--- a/inc/frontend/class-shortcodes.php
+++ b/inc/frontend/class-shortcodes.php
@@ -168,7 +168,9 @@ class AV_Petitioner_Shortcodes
 
     static public function get_available_fields()
     {
-        $available_fields = ['name', 'country', 'date_of_birth', 'salutation', 'city', 'postal_code', 'comments', 'submitted_at'];
+        $available_fields = AV_Petitioner_Submissions_Model::get_public_fields();
+        array_unshift($available_fields, 'name'); // Add name to the beginning of the array
+
         /**
          * Filter the available fields that are displayed in the submissions list
          * 

--- a/inc/submissions/class-submissions-controller.php
+++ b/inc/submissions/class-submissions-controller.php
@@ -279,14 +279,7 @@ class AV_Petitioner_Submissions_Controller
         $hide_last_name = get_post_meta($form_id, '_petitioner_hide_last_names', true);
 
         // Fetch submissions and total count using the new method
-        $public_fields = [
-            'country',
-            'city',
-            'postal_code',
-            'comments',
-            'submitted_at',
-            'date_of_birth'
-        ];
+        $public_fields = AV_Petitioner_Submissions_Model::get_public_fields();
 
         /**
          * Filter the public fields that are displayed in the submissions list

--- a/inc/submissions/class-submissions-model.php
+++ b/inc/submissions/class-submissions-model.php
@@ -472,4 +472,24 @@ class AV_Petitioner_Submissions_Model
 
         return $email_findings > 0;
     }
+
+    /**
+     * Get fields that are safe to display publicly
+     * 
+     * @return array Array of field names safe for public display
+     */
+    public static function get_public_fields()
+    {
+        // Calculate public fields: allowed minus sensitive
+        $public_fields = array_diff(
+            self::$ALLOWED_FIELDS,
+            self::$SENSITIVE_FIELDS
+        );
+
+        // Remove internal fields that shouldn't be displayed
+        $excluded_from_display = ['id', 'fname', 'lname', 'hide_name'];
+        $public_fields = array_diff($public_fields, $excluded_from_display);
+
+        return array_values($public_fields);
+    }
 }


### PR DESCRIPTION
## Description of change

[Issue link](https://github.com/avoy18/petitioner/issues/135)

Refactoring the submission display to to the following:
- Use 1 place for managing which fields are available publicly
- Ensure that all of the sensitive fields are filtered out and not shown on the frontend.
- Add new filters to modify this in the future