### PR TITLE
Issue #203: bugfix: get the correct behaviour of emails sent to rep

### DIFF
--- a/inc/emails/class-mailer.php
+++ b/inc/emails/class-mailer.php
@@ -76,7 +76,8 @@ class AV_Petitioner_Mailer
         ]; // what data to pass to the filter
 
         $submission     = !empty($this->submission_id) ? AV_Petitioner_Submissions_Model::get_submission_by_id($this->submission_id) : null;
-        $status         = ($submission && !empty($submission->email_status)) ? json_decode($submission->email_status, true) : [];
+        $status         = self::get_status($submission);
+
         $rep_email_sent = !empty($status['rep_email_sent']);
         $ty_email_sent  = !empty($status['ty_email_sent']);
 
@@ -256,5 +257,35 @@ class AV_Petitioner_Mailer
         }
 
         return $message;
+    }
+
+    /**
+     * Get email status from submission safely
+     *
+     * @since 0.8.2
+     *
+     * @param WP_Post|null $submission Submission
+     * @return array
+     */
+    public static function get_status($submission)
+    {
+        $status = ($submission && !empty($submission->email_status)) ? json_decode($submission->email_status, true) : [];
+        /**
+         * av_petitioner_submission_status
+         * 
+         * Filters the email status of a submission.
+         *
+         * @since 0.8.2
+         * 
+         * @param array $status The email status.
+         * @param WP_Post|null $submission The submission.
+         */
+        $status = apply_filters('av_petitioner_submission_status', $status, $submission);
+
+        if (!is_array($status)) {
+            $status = [];
+        }
+
+        return $status;
     }
 }

--- a/inc/emails/class-mailer.php
+++ b/inc/emails/class-mailer.php
@@ -75,6 +75,11 @@ class AV_Petitioner_Mailer
             'user_name'     => $this->user_name,
         ]; // what data to pass to the filter
 
+        $submission     = !empty($this->submission_id) ? AV_Petitioner_Submissions_Model::get_submission_by_id($this->submission_id) : null;
+        $status         = ($submission && !empty($submission->email_status)) ? json_decode($submission->email_status, true) : [];
+        $rep_email_sent = !empty($status['rep_email_sent']);
+        $ty_email_sent  = !empty($status['ty_email_sent']);
+
         /**
          * petitioner_send_ty_email
          * 
@@ -98,15 +103,32 @@ class AV_Petitioner_Mailer
          * @param array $filter_args The arguments passed to the filter.
          */
         $should_send_to_rep     = apply_filters('petitioner_send_to_representative', $this->send_to_representative, $filter_args);
+        $conf_result            = false;
+        $rep_result             = false;
 
-        if ($should_send_ty_email) {
-            $conf_result    = $this->ty_email();
-            $success        = $conf_result;
+        if ($should_send_ty_email && !$ty_email_sent) {
+            $conf_result = $this->ty_email();
+            $success = $success && $conf_result;
+
+            if ($conf_result && $submission) {
+                $status['ty_email_sent'] = true;
+            }
         }
 
-        if ($should_send_to_rep) {
+        if ($should_send_to_rep && !$rep_email_sent) {
             $rep_result = $this->representative_email();
-            $success = $rep_result && $conf_result;
+
+            $success = $success && $rep_result;
+
+            if ($rep_result && $submission) {
+                $status['rep_email_sent'] = true;
+            }
+        }
+
+        if ($submission && ($conf_result || $rep_result)) {
+            AV_Petitioner_Submissions_Model::update_submission($this->submission_id, [
+                'email_status' => wp_json_encode($status)
+            ]);
         }
 
         return $success;

--- a/inc/emails/class-mailer.php
+++ b/inc/emails/class-mailer.php
@@ -103,7 +103,8 @@ class AV_Petitioner_Mailer
          * @param bool  $should_send_to_rep Whether to send the rep you email.
          * @param array $filter_args The arguments passed to the filter.
          */
-        $should_send_to_rep     = apply_filters('petitioner_send_to_representative', $this->send_to_representative, $filter_args);
+        $is_confirmed = !$submission || !isset($submission->approval_status) || $submission->approval_status === 'Confirmed';
+        $should_send_to_rep     = $is_confirmed && apply_filters('petitioner_send_to_representative', $this->send_to_representative, $filter_args);
         $conf_result            = false;
         $rep_result             = false;
 

--- a/inc/submissions/class-csv-column-config.php
+++ b/inc/submissions/class-csv-column-config.php
@@ -244,7 +244,7 @@ class AV_Petitioner_Column_Config
     public static function get_exportable_fields()
     {
         $fields = array_values(array_filter(AV_Petitioner_Submissions_Model::$ALLOWED_FIELDS, static function ($field_id) {
-            return $field_id !== 'custom_properties';
+            return $field_id !== 'custom_properties' && $field_id !== 'email_status';
         }));
 
         /**

--- a/inc/submissions/class-csv-exporter.php
+++ b/inc/submissions/class-csv-exporter.php
@@ -232,8 +232,8 @@ class AV_Petitioner_CSV_Exporter
         $used_headers = []; // Track used headers to prevent duplicates
 
         foreach ($allowed_fields as $field) {
-            // Skip custom_properties - handled separately via filter
-            if ($field === 'custom_properties') {
+            // Skip custom_properties and email_status - handled separately or strictly internal
+            if ($field === 'custom_properties' || $field === 'email_status') {
                 continue;
             }
 
@@ -300,8 +300,8 @@ class AV_Petitioner_CSV_Exporter
         $row = [];
 
         foreach (AV_Petitioner_Submissions_Model::$ALLOWED_FIELDS as $field) {
-            // Skip custom_properties - handled separately via filter
-            if ($field === 'custom_properties') {
+            // Skip custom_properties and email_status - handled separately or strictly internal
+            if ($field === 'custom_properties' || $field === 'email_status') {
                 continue;
             }
 

--- a/inc/submissions/class-submissions-controller.php
+++ b/inc/submissions/class-submissions-controller.php
@@ -156,8 +156,6 @@ class AV_Petitioner_Submissions_Controller
             }
         }
 
-        $send_to_rep = $default_approval_status !== 'Email' && get_post_meta($form_id, '_petitioner_send_to_representative', true);
-
         $mailer_settings = array(
             'target_email'              => get_post_meta($form_id, '_petitioner_email', true),
             'target_cc_emails'          => get_post_meta($form_id, '_petitioner_cc_emails', true),
@@ -167,7 +165,7 @@ class AV_Petitioner_Submissions_Controller
             'letter'                    => get_post_meta($form_id, '_petitioner_letter', true),
             'subject'                   => get_post_meta($form_id, '_petitioner_subject', true),
             'bcc'                       => $bcc,
-            'send_to_representative'    => $send_to_rep,
+            'send_to_representative'    => $approval_status === 'Confirmed' && get_post_meta($form_id, '_petitioner_send_to_representative', true),
             'form_id'                   => $form_id,
             'confirm_emails'            => $default_approval_status === 'Email',
             'submission_id'             => $submission_id,
@@ -526,6 +524,12 @@ class AV_Petitioner_Submissions_Controller
         // so that CRMs and Webhooks recognize it's now ready for processing.
         if ($new_status === 'Confirmed' && $updated_rows > 0) {
             self::trigger_finalized_hook($id);
+
+            $submission = AV_Petitioner_Submissions_Model::get_submission_by_id($id);
+            if ($submission) {
+                // Send the representative email if enabled (skip TY and confirmation emails)
+                AV_Email_Confirmations::send_emails($submission, false, false);
+            }
         }
 
         wp_send_json_success([

--- a/inc/submissions/class-submissions-controller.php
+++ b/inc/submissions/class-submissions-controller.php
@@ -44,17 +44,9 @@ class AV_Petitioner_Submissions_Controller
         $hide_name                  = !empty($_POST['petitioner_hide_name']) && sanitize_text_field(wp_unslash($_POST['petitioner_hide_name'])) === 'on';
         $newsletter                 = !empty($_POST['petitioner_newsletter']) && sanitize_text_field(wp_unslash($_POST['petitioner_newsletter'])) === 'on';
         $require_approval           = get_post_meta($form_id, '_petitioner_require_approval', true);
-        $approval_status            = 'Confirmed';
-        $default_approval_status    = get_post_meta($form_id, '_petitioner_approval_state', true);
+        $default_approval_status    = get_post_meta($form_id, '_petitioner_approval_state', true); // Kept for confirm_emails below
+        $approval_status            = self::get_default_status($require_approval, $default_approval_status);
         $accept_tos                 = !empty($_POST['petitioner_accept_tos']) && sanitize_text_field(wp_unslash($_POST['petitioner_accept_tos'])) === 'on';
-
-        if ($require_approval) {
-            if ($default_approval_status === 'Email') {
-                $approval_status = 'Declined';
-            } else {
-                $approval_status = $default_approval_status;
-            }
-        }
 
         // handle captcha
         AV_Petitioner_Captcha::validate_captcha($form_id);
@@ -868,5 +860,26 @@ class AV_Petitioner_Submissions_Controller
         if (!$submission) return;
 
         AV_Email_Confirmations::send_emails($submission, false, false);
+    }
+
+    /**
+     * Get the default approval status for a new submission based on form settings.
+     * 
+     * @since 0.8.2
+     * 
+     * @param bool   $require_approval        Whether approval is required.
+     * @param string $default_approval_status The default approval state setting.
+     * @return string The default approval status ('Confirmed', 'Declined', or 'Pending').
+     */
+    public static function get_default_status($require_approval, $default_approval_status)
+    {
+        if ($require_approval) {
+            if ($default_approval_status === 'Email') {
+                return 'Declined';
+            }
+            return $default_approval_status;
+        }
+
+        return 'Confirmed';
     }
 }

--- a/inc/submissions/class-submissions-controller.php
+++ b/inc/submissions/class-submissions-controller.php
@@ -157,7 +157,7 @@ class AV_Petitioner_Submissions_Controller
             'letter'                    => get_post_meta($form_id, '_petitioner_letter', true),
             'subject'                   => get_post_meta($form_id, '_petitioner_subject', true),
             'bcc'                       => $bcc,
-            'send_to_representative'    => isset($data['approval_status']) && $data['approval_status'] === 'Confirmed' && get_post_meta($form_id, '_petitioner_send_to_representative', true),
+            'send_to_representative'    => get_post_meta($form_id, '_petitioner_send_to_representative', true),
             'form_id'                   => $form_id,
             'confirm_emails'            => $default_approval_status === 'Email',
             'submission_id'             => $submission_id,

--- a/inc/submissions/class-submissions-controller.php
+++ b/inc/submissions/class-submissions-controller.php
@@ -437,7 +437,7 @@ class AV_Petitioner_Submissions_Controller
 
         $updated_rows = AV_Petitioner_Submissions_Model::update_submission($id, $submission);
 
-        $approval_status = isset($_POST['approval_status']) ? sanitize_text_field(wp_unslash($_POST['approval_status'])) : null;
+        $approval_status = isset($submission['approval_status']) ? $submission['approval_status'] : null;
 
         if ($updated_rows === false) {
             wp_send_json_error(['message' => AV_Petitioner_Labels::get('error_generic')]);

--- a/inc/submissions/class-submissions-controller.php
+++ b/inc/submissions/class-submissions-controller.php
@@ -431,6 +431,10 @@ class AV_Petitioner_Submissions_Controller
          */
         $submission = apply_filters('av_petitioner_submission_data_pre_update', $submission, $_POST);
 
+        $old_submission = AV_Petitioner_Submissions_Model::get_submission_by_id($id);
+        $was_confirmed = $old_submission && $old_submission->approval_status === 'Confirmed';
+
+
         $updated_rows = AV_Petitioner_Submissions_Model::update_submission($id, $submission);
 
         $approval_status = isset($_POST['approval_status']) ? sanitize_text_field(wp_unslash($_POST['approval_status'])) : null;
@@ -438,8 +442,8 @@ class AV_Petitioner_Submissions_Controller
         if ($updated_rows === 0) {
             wp_send_json_error(['message' => AV_Petitioner_Labels::get('error_generic')]);
         }
-
-        if ($approval_status === 'Confirmed') {
+        // Only trigger if it WAS NOT confirmed before, and IS confirmed now
+        if (!$was_confirmed && $approval_status === 'Confirmed') {
             AV_Petitioner_Submissions_Controller::trigger_finalized_hook($id);
             AV_Petitioner_Submissions_Controller::trigger_final_emails($id);
         }
@@ -862,9 +866,8 @@ class AV_Petitioner_Submissions_Controller
     public static function trigger_final_emails($submission_id)
     {
         $submission = AV_Petitioner_Submissions_Model::get_submission_by_id($submission_id);
-        if ($submission) {
-            // Send the representative email if enabled (skip TY and confirmation emails)
-            AV_Email_Confirmations::send_emails($submission, false, false);
-        }
+        if (!$submission) return;
+
+        AV_Email_Confirmations::send_emails($submission, false, false);
     }
 }

--- a/inc/submissions/class-submissions-controller.php
+++ b/inc/submissions/class-submissions-controller.php
@@ -439,7 +439,7 @@ class AV_Petitioner_Submissions_Controller
 
         $approval_status = isset($_POST['approval_status']) ? sanitize_text_field(wp_unslash($_POST['approval_status'])) : null;
 
-        if ($updated_rows === false || $updated_rows === 0) {
+        if ($updated_rows === false) {
             wp_send_json_error(['message' => AV_Petitioner_Labels::get('error_generic')]);
         }
         // Only trigger if it WAS NOT confirmed before, and IS confirmed now

--- a/inc/submissions/class-submissions-controller.php
+++ b/inc/submissions/class-submissions-controller.php
@@ -151,7 +151,7 @@ class AV_Petitioner_Submissions_Controller
 
         if ($submission_id !== false) {
             // Only finalize if the starting state is fully confirmed (bypasses manual moderation and emails)
-            if ($approval_status === 'Confirmed') {
+            if (isset($data['approval_status']) && $data['approval_status'] === 'Confirmed') {
                 self::trigger_finalized_hook($submission_id);
             }
         }
@@ -165,7 +165,7 @@ class AV_Petitioner_Submissions_Controller
             'letter'                    => get_post_meta($form_id, '_petitioner_letter', true),
             'subject'                   => get_post_meta($form_id, '_petitioner_subject', true),
             'bcc'                       => $bcc,
-            'send_to_representative'    => $approval_status === 'Confirmed' && get_post_meta($form_id, '_petitioner_send_to_representative', true),
+            'send_to_representative'    => isset($data['approval_status']) && $data['approval_status'] === 'Confirmed' && get_post_meta($form_id, '_petitioner_send_to_representative', true),
             'form_id'                   => $form_id,
             'confirm_emails'            => $default_approval_status === 'Email',
             'submission_id'             => $submission_id,
@@ -433,7 +433,6 @@ class AV_Petitioner_Submissions_Controller
 
         $old_submission = AV_Petitioner_Submissions_Model::get_submission_by_id($id);
         $was_confirmed = $old_submission && $old_submission->approval_status === 'Confirmed';
-
 
         $updated_rows = AV_Petitioner_Submissions_Model::update_submission($id, $submission);
 

--- a/inc/submissions/class-submissions-controller.php
+++ b/inc/submissions/class-submissions-controller.php
@@ -435,8 +435,8 @@ class AV_Petitioner_Submissions_Controller
         }
         // Only trigger if it WAS NOT confirmed before, and IS confirmed now
         if (!$was_confirmed && $approval_status === 'Confirmed') {
-            AV_Petitioner_Submissions_Controller::trigger_finalized_hook($id);
-            AV_Petitioner_Submissions_Controller::trigger_final_emails($id);
+            self::trigger_finalized_hook($id);
+            self::trigger_final_emails($id);
         }
 
         wp_send_json_success(['message' => AV_Petitioner_Labels::get('success_generic'), 'updated_rows' => $updated_rows]);

--- a/inc/submissions/class-submissions-controller.php
+++ b/inc/submissions/class-submissions-controller.php
@@ -424,7 +424,12 @@ class AV_Petitioner_Submissions_Controller
         $submission = apply_filters('av_petitioner_submission_data_pre_update', $submission, $_POST);
 
         $old_submission = AV_Petitioner_Submissions_Model::get_submission_by_id($id);
-        $was_confirmed = $old_submission && $old_submission->approval_status === 'Confirmed';
+
+        if (!$old_submission) {
+            wp_send_json_error(['message' => AV_Petitioner_Labels::get('error_generic')]);
+        }
+
+        $was_confirmed = $old_submission->approval_status === 'Confirmed';
 
         $updated_rows = AV_Petitioner_Submissions_Model::update_submission($id, $submission);
 

--- a/inc/submissions/class-submissions-controller.php
+++ b/inc/submissions/class-submissions-controller.php
@@ -433,8 +433,15 @@ class AV_Petitioner_Submissions_Controller
 
         $updated_rows = AV_Petitioner_Submissions_Model::update_submission($id, $submission);
 
+        $approval_status = isset($_POST['approval_status']) ? sanitize_text_field(wp_unslash($_POST['approval_status'])) : null;
+
         if ($updated_rows === 0) {
             wp_send_json_error(['message' => AV_Petitioner_Labels::get('error_generic')]);
+        }
+
+        if ($approval_status === 'Confirmed') {
+            AV_Petitioner_Submissions_Controller::trigger_finalized_hook($id);
+            AV_Petitioner_Submissions_Controller::trigger_final_emails($id);
         }
 
         wp_send_json_success(['message' => AV_Petitioner_Labels::get('success_generic'), 'updated_rows' => $updated_rows]);
@@ -525,11 +532,7 @@ class AV_Petitioner_Submissions_Controller
         if ($new_status === 'Confirmed' && $updated_rows > 0) {
             self::trigger_finalized_hook($id);
 
-            $submission = AV_Petitioner_Submissions_Model::get_submission_by_id($id);
-            if ($submission) {
-                // Send the representative email if enabled (skip TY and confirmation emails)
-                AV_Email_Confirmations::send_emails($submission, false, false);
-            }
+            self::trigger_final_emails($id);
         }
 
         wp_send_json_success([
@@ -846,6 +849,22 @@ class AV_Petitioner_Submissions_Controller
              * @param int $form_id       The ID of the form associated with the submission.
              */
             do_action('petitioner_submission_finalized', $submission, $submission->form_id);
+        }
+    }
+
+    /**
+     * Helper method to uniformly trigger the representative email.
+     * 
+     * @param int $submission_id The submission ID
+     * @return void
+     * @since 0.8.2
+     */
+    public static function trigger_final_emails($submission_id)
+    {
+        $submission = AV_Petitioner_Submissions_Model::get_submission_by_id($submission_id);
+        if ($submission) {
+            // Send the representative email if enabled (skip TY and confirmation emails)
+            AV_Email_Confirmations::send_emails($submission, false, false);
         }
     }
 }

--- a/inc/submissions/class-submissions-controller.php
+++ b/inc/submissions/class-submissions-controller.php
@@ -439,7 +439,7 @@ class AV_Petitioner_Submissions_Controller
 
         $approval_status = isset($_POST['approval_status']) ? sanitize_text_field(wp_unslash($_POST['approval_status'])) : null;
 
-        if ($updated_rows === 0) {
+        if ($updated_rows === false || $updated_rows === 0) {
             wp_send_json_error(['message' => AV_Petitioner_Labels::get('error_generic')]);
         }
         // Only trigger if it WAS NOT confirmed before, and IS confirmed now

--- a/inc/submissions/class-submissions-model.php
+++ b/inc/submissions/class-submissions-model.php
@@ -31,7 +31,8 @@ class AV_Petitioner_Submissions_Model
         'submitted_at',
         'confirmation_token',
         'custom_properties',
-        'is_featured'
+        'is_featured',
+        'email_status'
     ];
 
     /**
@@ -61,7 +62,8 @@ class AV_Petitioner_Submissions_Model
         'lname',
         'hide_name',
         'custom_properties',
-        'is_featured'
+        'is_featured',
+        'email_status'
     ];
 
     public static function table_name()
@@ -98,6 +100,7 @@ class AV_Petitioner_Submissions_Model
             submitted_at datetime DEFAULT CURRENT_TIMESTAMP NOT NULL,
             confirmation_token varchar(64) DEFAULT NULL,
             custom_properties LONGTEXT DEFAULT NULL,
+            email_status LONGTEXT DEFAULT NULL,
             PRIMARY KEY  (id),
             KEY form_id (form_id)
         )";
@@ -429,6 +432,7 @@ class AV_Petitioner_Submissions_Model
             'submitted_at'          => '%s',
             'confirmation_token'    => '%s',
             'custom_properties'     => '%s',
+            'email_status'          => '%s',
         ];
 
         $formats = [];

--- a/tests/php/emails/test-mailer.php
+++ b/tests/php/emails/test-mailer.php
@@ -7,6 +7,7 @@ class Test_Mailer extends BaseTestCase
     public function set_up()
     {
         parent::set_up();
+        AV_Petitioner_Submissions_Model::create_db_table();
     }
 
     public function tear_down()
@@ -80,7 +81,7 @@ class Test_Mailer extends BaseTestCase
 
         $this->assertFalse($result, 'send_emails should return false when Rep email fails');
     }
-    
+
     public function test_send_emails_returns_true_when_both_emails_succeed()
     {
         $settings = [
@@ -107,7 +108,7 @@ class Test_Mailer extends BaseTestCase
         $mailer->expects($this->once())
             ->method('ty_email')
             ->willReturn(true);
-            
+
         $mailer->expects($this->once())
             ->method('representative_email')
             ->willReturn(true);
@@ -115,5 +116,47 @@ class Test_Mailer extends BaseTestCase
         $result = $mailer->send_emails();
 
         $this->assertTrue($result, 'send_emails should return true when both emails succeed');
+    }
+
+    public function test_send_emails_skips_sending_when_already_sent()
+    {
+        $settings = [
+            'target_email' => 'test@test.com',
+            'target_cc_emails' => '',
+            'user_email' => 'user@test.com',
+            'user_name' => 'John Doe',
+            'user_country' => 'US',
+            'subject' => 'Test',
+            'letter' => 'Test letter',
+            'bcc' => false,
+            'send_to_representative' => true,
+            'confirm_emails' => false,
+            'send_ty_email' => true,
+            'form_id' => 1,
+            'submission_id' => 999,
+        ];
+
+        $filter_callback = function () {
+            return ['ty_email_sent' => true, 'rep_email_sent' => true];
+        };
+
+        add_filter('av_petitioner_submission_status', $filter_callback, 10, 2);
+
+        $mailer = $this->getMockBuilder(AV_Petitioner_Mailer::class)
+            ->setConstructorArgs([$settings])
+            ->onlyMethods(['ty_email', 'representative_email'])
+            ->getMock();
+
+        $mailer->expects($this->never())
+            ->method('ty_email');
+
+        $mailer->expects($this->never())
+            ->method('representative_email');
+
+        $result = $mailer->send_emails();
+
+        $this->assertTrue($result, 'send_emails should return true and skip sending when both emails are already marked as sent');
+
+        remove_filter('av_petitioner_submission_status', $filter_callback, 10);
     }
 }

--- a/tests/php/emails/test-mailer.php
+++ b/tests/php/emails/test-mailer.php
@@ -1,0 +1,119 @@
+<?php
+
+use WorDBless\BaseTestCase;
+
+class Test_Mailer extends BaseTestCase
+{
+    public function set_up()
+    {
+        parent::set_up();
+    }
+
+    public function tear_down()
+    {
+        parent::tear_down();
+    }
+
+    public function test_send_emails_returns_true_when_ty_email_skipped_and_rep_email_succeeds()
+    {
+        $settings = [
+            'target_email' => 'test@test.com',
+            'target_cc_emails' => '',
+            'user_email' => 'user@test.com',
+            'user_name' => 'John Doe',
+            'user_country' => 'US',
+            'subject' => 'Test',
+            'letter' => 'Test letter',
+            'bcc' => false,
+            'send_to_representative' => true,
+            'confirm_emails' => false,
+            'send_ty_email' => false, // TY email is explicitly skipped
+            'form_id' => 1,
+            'submission_id' => 1,
+        ];
+
+        $mailer = $this->getMockBuilder(AV_Petitioner_Mailer::class)
+            ->setConstructorArgs([$settings])
+            ->onlyMethods(['ty_email', 'representative_email'])
+            ->getMock();
+
+        $mailer->expects($this->never())
+            ->method('ty_email');
+
+        $mailer->expects($this->once())
+            ->method('representative_email')
+            ->willReturn(true);
+
+        $result = $mailer->send_emails();
+
+        $this->assertTrue($result, 'send_emails should return true when TY email is skipped and Rep email succeeds');
+    }
+
+    public function test_send_emails_returns_false_when_rep_email_fails()
+    {
+        $settings = [
+            'target_email' => 'test@test.com',
+            'target_cc_emails' => '',
+            'user_email' => 'user@test.com',
+            'user_name' => 'John Doe',
+            'user_country' => 'US',
+            'subject' => 'Test',
+            'letter' => 'Test letter',
+            'bcc' => false,
+            'send_to_representative' => true,
+            'confirm_emails' => false,
+            'send_ty_email' => false,
+            'form_id' => 1,
+            'submission_id' => 1,
+        ];
+
+        $mailer = $this->getMockBuilder(AV_Petitioner_Mailer::class)
+            ->setConstructorArgs([$settings])
+            ->onlyMethods(['ty_email', 'representative_email'])
+            ->getMock();
+
+        $mailer->expects($this->once())
+            ->method('representative_email')
+            ->willReturn(false);
+
+        $result = $mailer->send_emails();
+
+        $this->assertFalse($result, 'send_emails should return false when Rep email fails');
+    }
+    
+    public function test_send_emails_returns_true_when_both_emails_succeed()
+    {
+        $settings = [
+            'target_email' => 'test@test.com',
+            'target_cc_emails' => '',
+            'user_email' => 'user@test.com',
+            'user_name' => 'John Doe',
+            'user_country' => 'US',
+            'subject' => 'Test',
+            'letter' => 'Test letter',
+            'bcc' => false,
+            'send_to_representative' => true,
+            'confirm_emails' => false,
+            'send_ty_email' => true,
+            'form_id' => 1,
+            'submission_id' => 1,
+        ];
+
+        $mailer = $this->getMockBuilder(AV_Petitioner_Mailer::class)
+            ->setConstructorArgs([$settings])
+            ->onlyMethods(['ty_email', 'representative_email'])
+            ->getMock();
+
+        $mailer->expects($this->once())
+            ->method('ty_email')
+            ->willReturn(true);
+            
+        $mailer->expects($this->once())
+            ->method('representative_email')
+            ->willReturn(true);
+
+        $result = $mailer->send_emails();
+
+        $this->assertTrue($result, 'send_emails should return true when both emails succeed');
+    }
+}

--- a/tests/php/submissions/test-csv-exporter.php
+++ b/tests/php/submissions/test-csv-exporter.php
@@ -176,9 +176,9 @@ class Test_CSV_Exporter extends BaseTestCase
 
         $row = AV_Petitioner_CSV_Exporter::get_csv_row($submission);
 
-        // custom_properties should be skipped (handled via filter)
-        // The row count should match allowed fields minus custom_properties
-        $expected_count = count(AV_Petitioner_Submissions_Model::$ALLOWED_FIELDS) - 1;
+        // custom_properties and email_status should be skipped (handled via filter or internal)
+        // The row count should match allowed fields minus custom_properties and email_status
+        $expected_count = count(AV_Petitioner_Submissions_Model::$ALLOWED_FIELDS) - 2;
         $this->assertCount($expected_count, $row);
     }
 

--- a/tests/php/submissions/test-csv-exporter.php
+++ b/tests/php/submissions/test-csv-exporter.php
@@ -162,7 +162,7 @@ class Test_CSV_Exporter extends BaseTestCase
         $row = AV_Petitioner_CSV_Exporter::get_csv_row($submission);
 
         // Should have values for all allowed fields (minus custom_properties)
-        $expected_count = count(AV_Petitioner_Submissions_Model::$ALLOWED_FIELDS) - 1; // -1 for custom_properties
+        $expected_count = count(AV_Petitioner_Submissions_Model::$ALLOWED_FIELDS) - 2; // -1 for custom_properties, -1 for email_status
         $this->assertCount($expected_count, $row);
     }
 
@@ -227,7 +227,7 @@ class Test_CSV_Exporter extends BaseTestCase
         $resolved = AV_Petitioner_Column_Config::resolve(1, $payload);
         $headers = AV_Petitioner_CSV_Exporter::get_csv_headers(1, $resolved);
 
-        $expected_count = count(AV_Petitioner_Submissions_Model::$ALLOWED_FIELDS) - 2; // -custom_properties, -email
+        $expected_count = count(AV_Petitioner_Submissions_Model::$ALLOWED_FIELDS) - 3; // -custom_properties, -email_status, -email
         $this->assertCount($expected_count, $headers);
         $this->assertContains('First Name', $headers);
     }
@@ -265,7 +265,7 @@ class Test_CSV_Exporter extends BaseTestCase
         $row = AV_Petitioner_CSV_Exporter::get_csv_row($submission, $resolved);
         $newsletter_idx = array_search('newsletter', $resolved['visible_columns'], true);
 
-        $expected_count = count(AV_Petitioner_Submissions_Model::$ALLOWED_FIELDS) - 2; // -custom_properties, -email
+        $expected_count = count(AV_Petitioner_Submissions_Model::$ALLOWED_FIELDS) - 3; // -custom_properties, -email_status, -email
         $this->assertCount($expected_count, $row);
         $this->assertNotFalse($newsletter_idx);
         $this->assertSame('No', $row[$newsletter_idx]);

--- a/tests/php/submissions/test-submissions-controller.php
+++ b/tests/php/submissions/test-submissions-controller.php
@@ -191,4 +191,22 @@ class Test_Submissions_Controller extends BaseTestCase
 
         remove_filter('av_petitioner_hide_last_name', $filter_callback, 10);
     }
+
+    public function test_get_default_status_no_approval_required()
+    {
+        $status = AV_Petitioner_Submissions_Controller::get_default_status(false, 'Confirmed');
+        $this->assertEquals('Confirmed', $status);
+    }
+
+    public function test_get_default_status_approval_required_email()
+    {
+        $status = AV_Petitioner_Submissions_Controller::get_default_status(true, 'Email');
+        $this->assertEquals('Declined', $status);
+    }
+
+    public function test_get_default_status_approval_required_pending()
+    {
+        $status = AV_Petitioner_Submissions_Controller::get_default_status(true, 'Pending');
+        $this->assertEquals('Pending', $status);
+    }
 }


### PR DESCRIPTION
## Description of change

[Issue link](https://github.com/avoy18/petitioner/issues/203)

- Ensure they are only sent on confirmed identities
- Send them on manual approvals via admin
- Track the submission status via a new db column and prevent sending them again if it was already sent