### PR TITLE
Issue #221: [Security] Remove unused active_tab property from petitioner info array

### DIFF
--- a/inc/admin-ui/edit-form/class-admin-edit-ui.php
+++ b/inc/admin-ui/edit-form/class-admin-edit-ui.php
@@ -140,8 +140,6 @@ class AV_Petitioner_Admin_Edit_UI
          */
         $petitioner_info['form_fields'] = apply_filters('av_petitioner_form_fields_admin', $petitioner_info['form_fields'], $post->ID);
 
-        $petitioner_info['active_tab']  = !empty($_GET['ptr_active_tab']) ? $_GET['ptr_active_tab'] : 'default';
-
         $data_attributes = wp_json_encode($petitioner_info, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
 ?>
         <div class="petitioner-admin__form ptr-is-loading">


### PR DESCRIPTION
## Description of change

[Issue link](https://github.com/avoy18/petitioner/issues/221)

Removing the _outdated_ active tab handling (we still have it using `AV_Petitioner_Admin_Shared`)