### PR TITLE
feat: add proper preview for the submissions GB block

### DIFF
--- a/inc/class-setup.php
+++ b/inc/class-setup.php
@@ -15,6 +15,7 @@ class AV_Petitioner_Setup
         // assets
         add_action('admin_enqueue_scripts', array($this, 'enqueue_admin_assets'));
         add_action('wp_enqueue_scripts',  array($this, 'enqueue_frontend_assets'));
+        add_action('enqueue_block_editor_assets', array($this, 'enqueue_frontend_assets'));
 
         add_filter('wp_script_attributes', function ($attributes) {
             if ('petitioner-script-js' === $attributes['id'] || 'petitioner-admin-script-js' === $attributes['id'] || 'petitioner-form-block-js' === $attributes['id']) {
@@ -191,7 +192,6 @@ class AV_Petitioner_Setup
      */
     public function enqueue_frontend_assets()
     {
-        if (is_admin()) return;
 
         wp_enqueue_style('petitioner-style', plugin_dir_url(dirname(__FILE__)) . 'dist/main.css', array(), AV_PETITIONER_PLUGIN_VERSION);
 

--- a/src/blocks/components/ServerComponent.tsx
+++ b/src/blocks/components/ServerComponent.tsx
@@ -67,7 +67,8 @@ export default function ServerComponent({
 	}
 
 	return (
-		<div style={{ pointerEvents: 'none' }}>
+		// @ts-expect-error inert is valid in React 18 and standard HTML
+		<div style={{ pointerEvents: 'none' }} inert="true">
 			{!noPreview ? (
 				<ServerSideRender block={blockName} attributes={attributes} />
 			) : (

--- a/src/blocks/submissions/Edit.tsx
+++ b/src/blocks/submissions/Edit.tsx
@@ -6,18 +6,17 @@ import {
 	ToggleControl,
 	SelectControl,
 } from '@wordpress/components';
-import { useSelect } from '@wordpress/data';
-import { useCallback } from '@wordpress/element';
+import { useSelect, useDispatch } from '@wordpress/data';
+import { useCallback, useEffect, useRef } from '@wordpress/element';
 import PetitionSelect from '../components/PetitionSelect';
 import ServerComponent from '../components/ServerComponent';
+import PetitionerSubmissions from '@js/frontend/submissions/index';
 import type { PetitionerSubmissionsProps, FieldType } from './consts';
 import { __ } from '@wordpress/i18n';
 import { FormTokenField } from '@wordpress/components';
 
-export default function Edit({
-	attributes,
-	setAttributes,
-}: PetitionerSubmissionsProps) {
+export default function Edit(props: PetitionerSubmissionsProps) {
+	const { attributes, setAttributes, clientId } = props;
 	const {
 		formId,
 		perPage = 10,
@@ -26,9 +25,37 @@ export default function Edit({
 		showPagination = true,
 		hidePageNumbers = false,
 		availableFields = [],
-		// availableStyles,
 	} = attributes;
+	
 	const blockAtts = useBlockProps();
+	const wrapperRef = useRef<HTMLDivElement>(null);
+	// @ts-ignore
+	const { selectBlock } = useDispatch('core/block-editor');
+
+	useEffect(() => {
+		if (!wrapperRef.current) return;
+
+		const initBlock = () => {
+			const submissionsDiv = wrapperRef.current?.querySelector(
+				'.petitioner-submissions:not([data-ptr-initialized])'
+			);
+			if (submissionsDiv instanceof HTMLElement) {
+				submissionsDiv.dataset.ptrInitialized = 'true';
+				new PetitionerSubmissions(submissionsDiv);
+			}
+		};
+
+		// Initial check in case it's already rendered
+		initBlock();
+
+		const observer = new MutationObserver(() => {
+			initBlock();
+		});
+
+		observer.observe(wrapperRef.current, { childList: true, subtree: true });
+
+		return () => observer.disconnect();
+	}, []);
 
 	const fetchPetitions = useCallback(() => {
 		return useSelect((select) => {
@@ -46,18 +73,17 @@ export default function Edit({
 
 	const allPetitions = fetchPetitions() || [];
 
+	const handleSelect = () => {
+		selectBlock(clientId);
+	};
+
 	return (
-		<div {...blockAtts}>
+		<div {...blockAtts} ref={wrapperRef} onClickCapture={handleSelect} style={{ minHeight: '150px' }}>
 			<ServerComponent
 				title={__('Petitioner Submissions', 'petitioner')}
 				blockName="petitioner/submissions"
 				attributes={attributes}
 				allPetitions={allPetitions}
-				noPreview={true}
-				customPreviewMessage={__(
-					'Submissions will load on the frontend',
-					'petitioner'
-				)}
 			/>
 			<InspectorControls>
 				<PanelBody>
@@ -96,8 +122,8 @@ export default function Edit({
 						label={__('Fields to show', 'petitioner')}
 						value={fields}
 						suggestions={availableFields}
-						onChange={(value ) => {
-							setAttributes({ fields: value});
+						onChange={(value) => {
+							setAttributes({ fields: value });
 						}}
 						__experimentalExpandOnFocus={true}
 						placeholder={__(

--- a/src/blocks/submissions/Edit.tsx
+++ b/src/blocks/submissions/Edit.tsx
@@ -39,8 +39,14 @@ export default function Edit(props: PetitionerSubmissionsProps) {
 				'.petitioner-submissions:not([data-ptr-initialized])'
 			);
 			if (submissionsDiv instanceof HTMLElement) {
-				submissionsDiv.dataset.ptrInitialized = 'true';
-				new PetitionerSubmissions(submissionsDiv);
+				try {
+					new PetitionerSubmissions(submissionsDiv);
+					// Only mark as initialized if construction succeeds
+					submissionsDiv.dataset.ptrInitialized = 'true';
+				} catch (err) {
+					// If data isn't ready, let it fail silently.
+					// The next DOM mutation tick will retry this node.
+				}
 			}
 		};
 

--- a/src/blocks/submissions/Edit.tsx
+++ b/src/blocks/submissions/Edit.tsx
@@ -78,7 +78,7 @@ export default function Edit(props: PetitionerSubmissionsProps) {
 	};
 
 	return (
-		<div {...blockAtts} ref={wrapperRef} onClickCapture={handleSelect} style={{ minHeight: '150px' }}>
+		<div {...blockAtts} ref={wrapperRef} onClickCapture={handleSelect}>
 			<ServerComponent
 				title={__('Petitioner Submissions', 'petitioner')}
 				blockName="petitioner/submissions"

--- a/src/blocks/submissions/Edit.tsx
+++ b/src/blocks/submissions/Edit.tsx
@@ -26,10 +26,9 @@ export default function Edit(props: PetitionerSubmissionsProps) {
 		hidePageNumbers = false,
 		availableFields = [],
 	} = attributes;
-	
+
 	const blockAtts = useBlockProps();
 	const wrapperRef = useRef<HTMLDivElement>(null);
-	// @ts-ignore
 	const { selectBlock } = useDispatch('core/block-editor');
 
 	useEffect(() => {

--- a/src/blocks/submissions/consts.ts
+++ b/src/blocks/submissions/consts.ts
@@ -17,4 +17,5 @@ export type PetitionFormBlockAttributes = {
 export type PetitionerSubmissionsProps = {
 	attributes: PetitionFormBlockAttributes;
 	setAttributes: (attrs: Partial<PetitionFormBlockAttributes>) => void;
+	clientId: string
 };

--- a/src/blocks/submissions/consts.ts
+++ b/src/blocks/submissions/consts.ts
@@ -17,5 +17,5 @@ export type PetitionFormBlockAttributes = {
 export type PetitionerSubmissionsProps = {
 	attributes: PetitionFormBlockAttributes;
 	setAttributes: (attrs: Partial<PetitionFormBlockAttributes>) => void;
-	clientId: string
+	clientId: string;
 };

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,0 +1,14 @@
+const defaultConfig = require( '@wordpress/scripts/config/webpack.config' );
+const path = require( 'path' );
+
+module.exports = {
+	...defaultConfig,
+	resolve: {
+		...defaultConfig.resolve,
+		alias: {
+			...defaultConfig.resolve.alias,
+			'@js': path.resolve( __dirname, 'src/js/' ),
+			'@admin': path.resolve( __dirname, 'src/js/admin/' ),
+		},
+	},
+};


### PR DESCRIPTION
## Description of change

Description here

- Item
- Item


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Block editor support has been improved so the submissions block can be selected and edited more naturally.
  * Frontend assets now load correctly in the editor preview, improving how the block appears inside WordPress.

* **Bug Fixes**
  * Fixed preview initialization so the submissions interface is set up reliably.
  * Made embedded content behave as non-interactive while preventing accidental clicks.
  * Improved build configuration for more reliable asset loading and development paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->