### PR TITLE
Release 0.8.5: Improved visual customizer

### DIFF
--- a/inc/admin-ui/settings/admin-settings-schema.php
+++ b/inc/admin-ui/settings/admin-settings-schema.php
@@ -21,6 +21,30 @@ return [
         'meta_key' => 'petitioner_custom_css',
         'type'     => 'textarea'
     ],
+    'border_radius'        => [
+        'meta_key' => 'petitioner_border_radius',
+        'type'     => 'text'
+    ],
+    'base_font_size'       => [
+        'meta_key' => 'petitioner_base_font_size',
+        'type'     => 'text'
+    ],
+    'button_font_size'     => [
+        'meta_key' => 'petitioner_button_font_size',
+        'type'     => 'text'
+    ],
+    'field_spacing'        => [
+        'meta_key' => 'petitioner_field_spacing',
+        'type'     => 'text'
+    ],
+    'input_border_width'   => [
+        'meta_key' => 'petitioner_input_border_width',
+        'type'     => 'text'
+    ],
+    'input_size'           => [
+        'meta_key' => 'petitioner_input_size',
+        'type'     => 'text'
+    ],
     'primary_color'        => [
         'meta_key' => 'petitioner_primary_color',
         'type'     => 'text'

--- a/inc/admin-ui/settings/class-admin-live-preview.php
+++ b/inc/admin-ui/settings/class-admin-live-preview.php
@@ -65,7 +65,7 @@ class AV_Petitioner_Admin_Live_Preview
         $css = AV_Petitioner_Dynamic_CSS::generate_css($payload);
 
         // Sanitize the final CSS to prevent XSS/HTML injection while preserving valid CSS chars like <
-        $css = preg_replace('#<\s*/?\s*style[^>]*>#is', '', $css);
+        $css = preg_replace('#<\s*/?\s*style\b[^>]*>?#is', '', $css);
 
         wp_send_json_success(['css' => $css]);
     }

--- a/inc/admin-ui/settings/class-admin-live-preview.php
+++ b/inc/admin-ui/settings/class-admin-live-preview.php
@@ -64,9 +64,6 @@ class AV_Petitioner_Admin_Live_Preview
         // Pass payload as overrides to the dynamic CSS generator
         $css = AV_Petitioner_Dynamic_CSS::generate_css($payload);
 
-        // Sanitize the final CSS to prevent XSS/HTML injection while preserving valid CSS chars like <
-        $css = preg_replace('#<\s*/?\s*style\b[^>]*>?#is', '', $css);
-
         wp_send_json_success(['css' => $css]);
     }
 

--- a/inc/admin-ui/settings/class-admin-live-preview.php
+++ b/inc/admin-ui/settings/class-admin-live-preview.php
@@ -56,7 +56,10 @@ class AV_Petitioner_Admin_Live_Preview
 
         check_ajax_referer(self::NONCE_ACTION, 'petitioner_nonce');
 
-        $payload = isset($_POST['payload']) ? (array) $_POST['payload'] : [];
+        $payload = isset($_POST['payload']) ? json_decode(wp_unslash($_POST['payload']), true) : [];
+        if (!is_array($payload)) {
+            $payload = [];
+        }
         
         // Pass payload as overrides to the dynamic CSS generator
         $css = AV_Petitioner_Dynamic_CSS::generate_css($payload);

--- a/inc/admin-ui/settings/class-admin-live-preview.php
+++ b/inc/admin-ui/settings/class-admin-live-preview.php
@@ -58,7 +58,7 @@ class AV_Petitioner_Admin_Live_Preview
         <head>
             <meta charset="<?php bloginfo('charset'); ?>">
             <meta name="viewport" content="width=device-width, initial-scale=1.0">
-            <title>Petitioner Live Preview</title>
+            <title><?php esc_html_e('Petitioner Live Preview', 'petitioner'); ?></title>
             <?php wp_head(); ?>
             <style>
                 body {

--- a/inc/admin-ui/settings/class-admin-live-preview.php
+++ b/inc/admin-ui/settings/class-admin-live-preview.php
@@ -151,15 +151,12 @@ class AV_Petitioner_Admin_Live_Preview
      */
     public static function render_preview_script()
     {
-        $admin_url = admin_url();
     ?>
         <script>
-            const adminOrigin = new URL('<?php echo esc_js($admin_url); ?>', window.location.href).origin;
-
             // Listen for messages from the parent window
             window.addEventListener('message', function(event) {
                 // Verify the message comes from the WordPress admin dashboard
-                if (event.origin !== adminOrigin) return;
+                if (event.origin !== window.location.origin) return;
 
                 if (event.data && event.data.type === 'UPDATE_VISIBILITY') {
                     const payload = event.data.payload;

--- a/inc/admin-ui/settings/class-admin-live-preview.php
+++ b/inc/admin-ui/settings/class-admin-live-preview.php
@@ -1,0 +1,187 @@
+<?php
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+class AV_Petitioner_Admin_Live_Preview
+{
+    public static function init()
+    {
+        add_action('wp_ajax_petitioner_live_preview', [self::class, 'render_preview']);
+    }
+
+    public static function render_preview()
+    {
+        // Only allow admins
+        if (!current_user_can('manage_options')) {
+            wp_die('Unauthorized', 403);
+        }
+
+        $css_url = plugins_url('dist/main.css', AV_PETITIONER_PLUGIN_DIR . 'petitioner.php');
+        $css_path = AV_PETITIONER_PLUGIN_DIR . 'dist/main.css';
+        $css_ver = file_exists($css_path) ? filemtime($css_path) : AV_PETITIONER_PLUGIN_VERSION;
+        
+        // Generate the initial dynamic CSS based on saved settings
+        $initial_dynamic_css = '';
+        if (class_exists('AV_Petitioner_Dynamic_CSS')) {
+            $initial_dynamic_css = AV_Petitioner_Dynamic_CSS::generate_css();
+        }
+
+        ?>
+        <!DOCTYPE html>
+        <html lang="en">
+        <head>
+            <meta charset="UTF-8">
+            <meta name="viewport" content="width=device-width, initial-scale=1.0">
+            <title>Petitioner Live Preview</title>
+            <link rel="stylesheet" href="<?php echo esc_url($css_url); ?>?ver=<?php echo esc_attr($css_ver); ?>">
+            <style id="petitioner-dynamic-css">
+                <?php echo wp_strip_all_tags($initial_dynamic_css); ?>
+            </style>
+            <style>
+                body {
+                    background: transparent; 
+                    margin: 0;
+                    padding: 20px;
+                    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
+                }
+            </style>
+        </head>
+        <body>
+            <?php
+            $petitions = get_posts([
+                'post_type' => 'petitioner-petition',
+                'posts_per_page' => 1,
+                'post_status' => 'any'
+            ]);
+
+            if (!empty($petitions)) {
+                $frontend_ui = new AV_Petitioner_Frontend_UI();
+                echo $frontend_ui->display_form(['id' => $petitions[0]->ID]);
+            } else {
+                echo '<div class="petitioner"><div class="ptr-wrapper" style="padding: 20px; text-align: center;">';
+                echo '<p>' . esc_html__('Please create at least one petition to see the live preview.', 'petitioner') . '</p>';
+                echo '</div></div>';
+            }
+            ?>
+
+            <script>
+                // Listen for messages from the parent window
+                window.addEventListener('message', function(event) {
+                    if (event.data && event.data.type === 'UPDATE_SETTINGS') {
+                        const payload = event.data.payload;
+                        const root = document.querySelector('.petitioner');
+                        if (!root) return;
+                        
+                        // Toggle elements based on settings
+                        const titleEl = document.querySelector('.petitioner__title');
+                        if (titleEl) titleEl.style.display = payload.show_title ? 'block' : 'none';
+                        
+                        const letterEl = document.querySelector('.petitioner__btn--letter');
+                        if (letterEl) letterEl.style.display = payload.show_letter ? 'block' : 'none';
+
+                        const goalEl = document.querySelector('.petitioner__goal');
+                        if (goalEl) goalEl.style.display = payload.show_goal ? 'flex' : 'none';
+
+                        // Apply custom CSS
+                        let customStyleEl = document.getElementById('preview-custom-css');
+                        if (!customStyleEl) {
+                            customStyleEl = document.createElement('style');
+                            customStyleEl.id = 'preview-custom-css';
+                            document.head.appendChild(customStyleEl);
+                        }
+                        customStyleEl.textContent = payload.custom_css || '';
+
+                        const setVar = (name, val) => {
+                            if (val) {
+                                root.style.setProperty(name, val, 'important');
+                            } else {
+                                root.style.removeProperty(name);
+                            }
+                        };
+
+                        // Colors
+                        setVar('--ptr-color-primary', payload.primary_color);
+                        setVar('--ptr-color-dark', payload.dark_color);
+                        setVar('--ptr-color-grey', payload.grey_color);
+
+                        // Border Radius
+                        if (payload.border_radius) {
+                            setVar('--ptr-input-border-radius', `var(--ptr-border-radius-${payload.border_radius})`);
+                            setVar('--ptr-button-border-radius', `var(--ptr-border-radius-${payload.border_radius})`);
+                            
+                            let wrapperRadius = payload.border_radius === 'full' ? 'lg' : payload.border_radius;
+                            setVar('--ptr-wrapper-radius', `var(--ptr-border-radius-${wrapperRadius})`);
+                        } else {
+                            root.style.removeProperty('--ptr-input-border-radius');
+                            root.style.removeProperty('--ptr-button-border-radius');
+                            root.style.removeProperty('--ptr-wrapper-radius');
+                        }
+
+                        // Base Font Size
+                        if (payload.base_font_size) {
+                            setVar('--ptr-label-font-size', `var(--ptr-fs-${payload.base_font_size})`);
+                        } else {
+                            root.style.removeProperty('--ptr-label-font-size');
+                        }
+
+                        // Button Font Size
+                        if (payload.button_font_size) {
+                            setVar('--ptr-btn-font-size', `var(--ptr-fs-${payload.button_font_size})`);
+                        } else {
+                            root.style.removeProperty('--ptr-btn-font-size');
+                        }
+
+                        // Spacing
+                        if (payload.field_spacing) {
+                            setVar('--ptr-input-margin-bottom', `var(--ptr-spacer-${payload.field_spacing})`);
+                        } else {
+                            root.style.removeProperty('--ptr-input-margin-bottom');
+                        }
+
+                        // Border width
+                        if (payload.input_border_width) {
+                            setVar('--ptr-input-border-width', payload.input_border_width);
+                        } else {
+                            root.style.removeProperty('--ptr-input-border-width');
+                        }
+
+                        // Input Size
+                        if (payload.input_size) {
+                            switch(payload.input_size) {
+                                case 'sm':
+                                    setVar('--ptr-input-line-height', '24px');
+                                    setVar('--ptr-input-spacing-y', '4px');
+                                    setVar('--ptr-label-line-height', '1.4');
+                                    break;
+                                case 'md':
+                                    setVar('--ptr-input-line-height', '24px');
+                                    setVar('--ptr-input-spacing-y', '8px');
+                                    root.style.removeProperty('--ptr-label-line-height');
+                                    break;
+                                case 'lg':
+                                    setVar('--ptr-input-line-height', '32px');
+                                    setVar('--ptr-input-spacing-y', '8px');
+                                    root.style.removeProperty('--ptr-label-line-height');
+                                    break;
+                                case 'xl':
+                                    setVar('--ptr-input-line-height', '40px');
+                                    setVar('--ptr-input-spacing-y', '0.7rem');
+                                    root.style.removeProperty('--ptr-label-line-height');
+                                    break;
+                            }
+                        } else {
+                            root.style.removeProperty('--ptr-input-line-height');
+                            root.style.removeProperty('--ptr-input-spacing-y');
+                            root.style.removeProperty('--ptr-label-line-height');
+                        }
+                    }
+                });
+            </script>
+        </body>
+        </html>
+        <?php
+        wp_die();
+    }
+}

--- a/inc/admin-ui/settings/class-admin-live-preview.php
+++ b/inc/admin-ui/settings/class-admin-live-preview.php
@@ -8,187 +8,179 @@ class AV_Petitioner_Admin_Live_Preview
 {
     public static function init()
     {
-        add_action('wp_ajax_petitioner_live_preview', [self::class, 'render_preview']);
+        add_action('template_redirect', [self::class, 'render_preview']);
     }
 
     public static function render_preview()
     {
+        if (!isset($_GET['petitioner_live_preview'])) {
+            return;
+        }
+
         // Only allow admins
         if (!current_user_can('manage_options')) {
             wp_die('Unauthorized', 403);
         }
 
-        $css_url = plugins_url('dist/main.css', AV_PETITIONER_PLUGIN_DIR . 'petitioner.php');
-        $css_path = AV_PETITIONER_PLUGIN_DIR . 'dist/main.css';
-        $css_ver = file_exists($css_path) ? filemtime($css_path) : AV_PETITIONER_PLUGIN_VERSION;
+        $form_id = isset($_GET['form_id']) ? intval($_GET['form_id']) : 0;
         
-        // Generate the initial dynamic CSS based on saved settings
-        $initial_dynamic_css = '';
-        if (class_exists('AV_Petitioner_Dynamic_CSS')) {
-            $initial_dynamic_css = AV_Petitioner_Dynamic_CSS::generate_css();
-        }
+        // Remove admin bar for the preview
+        add_filter('show_admin_bar', '__return_false');
+        
+        // Add the postMessage listener script to the footer
+        add_action('wp_footer', [self::class, 'render_preview_script'], 999);
 
         ?>
         <!DOCTYPE html>
-        <html lang="en">
+        <html <?php language_attributes(); ?>>
         <head>
-            <meta charset="UTF-8">
+            <meta charset="<?php bloginfo('charset'); ?>">
             <meta name="viewport" content="width=device-width, initial-scale=1.0">
             <title>Petitioner Live Preview</title>
-            <link rel="stylesheet" href="<?php echo esc_url($css_url); ?>?ver=<?php echo esc_attr($css_ver); ?>">
-            <style id="petitioner-dynamic-css">
-                <?php echo wp_strip_all_tags($initial_dynamic_css); ?>
-            </style>
+            <?php wp_head(); ?>
             <style>
                 body {
                     background: transparent; 
                     margin: 0;
                     padding: 20px;
-                    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
                 }
+                html { margin-top: 0 !important; }
             </style>
         </head>
-        <body>
-            <?php
-            $form_id = isset($_GET['form_id']) ? intval($_GET['form_id']) : 0;
-            $petitions = [];
-
-            if ($form_id) {
-                $petitions = [get_post($form_id)];
-            } else {
-                $petitions = get_posts([
-                    'post_type' => 'petitioner-petition',
-                    'posts_per_page' => 1,
-                    'post_status' => 'any'
-                ]);
-            }
-
-            if (!empty($petitions) && $petitions[0]) {
-                $frontend_ui = new AV_Petitioner_Frontend_UI();
-                echo $frontend_ui->display_form(['id' => $petitions[0]->ID]);
-            } else {
-                echo '<div class="petitioner"><div class="ptr-wrapper" style="padding: 20px; text-align: center;">';
-                echo '<p>' . esc_html__('Please create at least one petition to see the live preview.', 'petitioner') . '</p>';
-                echo '</div></div>';
-            }
-            ?>
-
-            <script>
-                // Listen for messages from the parent window
-                window.addEventListener('message', function(event) {
-                    if (event.data && event.data.type === 'UPDATE_SETTINGS') {
-                        const payload = event.data.payload;
-                        const root = document.querySelector('.petitioner');
-                        if (!root) return;
-                        
-                        // Toggle elements based on settings
-                        const titleEl = document.querySelector('.petitioner__title');
-                        if (titleEl) titleEl.style.display = payload.show_title ? 'block' : 'none';
-                        
-                        const letterEl = document.querySelector('.petitioner__btn--letter');
-                        if (letterEl) letterEl.style.display = payload.show_letter ? 'block' : 'none';
-
-                        const goalEl = document.querySelector('.petitioner__goal');
-                        if (goalEl) goalEl.style.display = payload.show_goal ? 'flex' : 'none';
-
-                        // Apply custom CSS
-                        let customStyleEl = document.getElementById('preview-custom-css');
-                        if (!customStyleEl) {
-                            customStyleEl = document.createElement('style');
-                            customStyleEl.id = 'preview-custom-css';
-                            document.head.appendChild(customStyleEl);
-                        }
-                        customStyleEl.textContent = payload.custom_css || '';
-
-                        const setVar = (name, val) => {
-                            if (val) {
-                                root.style.setProperty(name, val, 'important');
-                            } else {
-                                root.style.removeProperty(name);
-                            }
-                        };
-
-                        // Colors
-                        setVar('--ptr-color-primary', payload.primary_color);
-                        setVar('--ptr-color-dark', payload.dark_color);
-                        setVar('--ptr-color-grey', payload.grey_color);
-
-                        // Border Radius
-                        if (payload.border_radius) {
-                            setVar('--ptr-input-border-radius', `var(--ptr-border-radius-${payload.border_radius})`);
-                            setVar('--ptr-button-border-radius', `var(--ptr-border-radius-${payload.border_radius})`);
-                            
-                            let wrapperRadius = payload.border_radius === 'full' ? 'lg' : payload.border_radius;
-                            setVar('--ptr-wrapper-radius', `var(--ptr-border-radius-${wrapperRadius})`);
-                        } else {
-                            root.style.removeProperty('--ptr-input-border-radius');
-                            root.style.removeProperty('--ptr-button-border-radius');
-                            root.style.removeProperty('--ptr-wrapper-radius');
-                        }
-
-                        // Base Font Size
-                        if (payload.base_font_size) {
-                            setVar('--ptr-label-font-size', `var(--ptr-fs-${payload.base_font_size})`);
-                        } else {
-                            root.style.removeProperty('--ptr-label-font-size');
-                        }
-
-                        // Button Font Size
-                        if (payload.button_font_size) {
-                            setVar('--ptr-btn-font-size', `var(--ptr-fs-${payload.button_font_size})`);
-                        } else {
-                            root.style.removeProperty('--ptr-btn-font-size');
-                        }
-
-                        // Spacing
-                        if (payload.field_spacing) {
-                            setVar('--ptr-input-margin-bottom', `var(--ptr-spacer-${payload.field_spacing})`);
-                        } else {
-                            root.style.removeProperty('--ptr-input-margin-bottom');
-                        }
-
-                        // Border width
-                        if (payload.input_border_width) {
-                            setVar('--ptr-input-border-width', payload.input_border_width);
-                        } else {
-                            root.style.removeProperty('--ptr-input-border-width');
-                        }
-
-                        // Input Size
-                        if (payload.input_size) {
-                            switch(payload.input_size) {
-                                case 'sm':
-                                    setVar('--ptr-input-line-height', '24px');
-                                    setVar('--ptr-input-spacing-y', '4px');
-                                    setVar('--ptr-label-line-height', '1.4');
-                                    break;
-                                case 'md':
-                                    setVar('--ptr-input-line-height', '24px');
-                                    setVar('--ptr-input-spacing-y', '8px');
-                                    root.style.removeProperty('--ptr-label-line-height');
-                                    break;
-                                case 'lg':
-                                    setVar('--ptr-input-line-height', '32px');
-                                    setVar('--ptr-input-spacing-y', '8px');
-                                    root.style.removeProperty('--ptr-label-line-height');
-                                    break;
-                                case 'xl':
-                                    setVar('--ptr-input-line-height', '40px');
-                                    setVar('--ptr-input-spacing-y', '0.7rem');
-                                    root.style.removeProperty('--ptr-label-line-height');
-                                    break;
-                            }
-                        } else {
-                            root.style.removeProperty('--ptr-input-line-height');
-                            root.style.removeProperty('--ptr-input-spacing-y');
-                            root.style.removeProperty('--ptr-label-line-height');
-                        }
-                    }
-                });
-            </script>
+        <body <?php body_class(); ?>>
+            <div class="petitioner-preview-wrapper petitioner-preview" style="max-width: 800px; margin: 40px auto; padding: 20px;">
+                <?php
+                if ($form_id) {
+                    $frontend_ui = new AV_Petitioner_Frontend_UI();
+                    echo $frontend_ui->display_form(['id' => $form_id]);
+                } else {
+                    echo '<p>' . esc_html__('Please create at least one petition to see the live preview.', 'petitioner') . '</p>';
+                }
+                ?>
+            </div>
+            <?php wp_footer(); ?>
         </body>
         </html>
         <?php
-        wp_die();
+        exit;
+    }
+
+    public static function render_preview_script()
+    {
+        ?>
+        <script>
+            // Listen for messages from the parent window
+            window.addEventListener('message', function(event) {
+                if (event.data && event.data.type === 'UPDATE_SETTINGS') {
+                    const payload = event.data.payload;
+                    const root = document.querySelector('.petitioner');
+                    if (!root) return;
+                    
+                    // Toggle elements based on settings
+                    const titleEl = document.querySelector('.petitioner__title');
+                    if (titleEl) titleEl.style.display = payload.show_title ? 'block' : 'none';
+                    
+                    const letterEl = document.querySelector('.petitioner__btn--letter');
+                    if (letterEl) letterEl.style.display = payload.show_letter ? 'block' : 'none';
+
+                    const goalEl = document.querySelector('.petitioner__goal');
+                    if (goalEl) goalEl.style.display = payload.show_goal ? 'flex' : 'none';
+
+                    // Apply custom CSS
+                    let customStyleEl = document.getElementById('preview-custom-css');
+                    if (!customStyleEl) {
+                        customStyleEl = document.createElement('style');
+                        customStyleEl.id = 'preview-custom-css';
+                        document.head.appendChild(customStyleEl);
+                    }
+                    customStyleEl.textContent = payload.custom_css || '';
+
+                    const setVar = (name, val) => {
+                        if (val) {
+                            root.style.setProperty(name, val, 'important');
+                        } else {
+                            root.style.removeProperty(name);
+                        }
+                    };
+
+                    // Colors
+                    setVar('--ptr-color-primary', payload.primary_color);
+                    setVar('--ptr-color-dark', payload.dark_color);
+                    setVar('--ptr-color-grey', payload.grey_color);
+
+                    // Border Radius
+                    if (payload.border_radius) {
+                        setVar('--ptr-input-border-radius', `var(--ptr-border-radius-${payload.border_radius})`);
+                        setVar('--ptr-button-border-radius', `var(--ptr-border-radius-${payload.border_radius})`);
+                        
+                        let wrapperRadius = payload.border_radius === 'full' ? 'lg' : payload.border_radius;
+                        setVar('--ptr-wrapper-radius', `var(--ptr-border-radius-${wrapperRadius})`);
+                    } else {
+                        root.style.removeProperty('--ptr-input-border-radius');
+                        root.style.removeProperty('--ptr-button-border-radius');
+                        root.style.removeProperty('--ptr-wrapper-radius');
+                    }
+
+                    // Base Font Size
+                    if (payload.base_font_size) {
+                        setVar('--ptr-label-font-size', `var(--ptr-fs-${payload.base_font_size})`);
+                    } else {
+                        root.style.removeProperty('--ptr-label-font-size');
+                    }
+
+                    // Button Font Size
+                    if (payload.button_font_size) {
+                        setVar('--ptr-btn-font-size', `var(--ptr-fs-${payload.button_font_size})`);
+                    } else {
+                        root.style.removeProperty('--ptr-btn-font-size');
+                    }
+
+                    // Spacing
+                    if (payload.field_spacing) {
+                        setVar('--ptr-input-margin-bottom', `var(--ptr-spacer-${payload.field_spacing})`);
+                    } else {
+                        root.style.removeProperty('--ptr-input-margin-bottom');
+                    }
+
+                    // Border width
+                    if (payload.input_border_width) {
+                        setVar('--ptr-input-border-width', payload.input_border_width);
+                    } else {
+                        root.style.removeProperty('--ptr-input-border-width');
+                    }
+
+                    // Input Size
+                    if (payload.input_size) {
+                        switch(payload.input_size) {
+                            case 'sm':
+                                setVar('--ptr-input-line-height', '24px');
+                                setVar('--ptr-input-spacing-y', '4px');
+                                setVar('--ptr-label-line-height', '1.4');
+                                break;
+                            case 'md':
+                                setVar('--ptr-input-line-height', '24px');
+                                setVar('--ptr-input-spacing-y', '8px');
+                                root.style.removeProperty('--ptr-label-line-height');
+                                break;
+                            case 'lg':
+                                setVar('--ptr-input-line-height', '32px');
+                                setVar('--ptr-input-spacing-y', '8px');
+                                root.style.removeProperty('--ptr-label-line-height');
+                                break;
+                            case 'xl':
+                                setVar('--ptr-input-line-height', '40px');
+                                setVar('--ptr-input-spacing-y', '0.7rem');
+                                root.style.removeProperty('--ptr-label-line-height');
+                                break;
+                        }
+                    } else {
+                        root.style.removeProperty('--ptr-input-line-height');
+                        root.style.removeProperty('--ptr-input-spacing-y');
+                        root.style.removeProperty('--ptr-label-line-height');
+                    }
+                }
+            });
+        </script>
+        <?php
     }
 }

--- a/inc/admin-ui/settings/class-admin-live-preview.php
+++ b/inc/admin-ui/settings/class-admin-live-preview.php
@@ -124,7 +124,7 @@ class AV_Petitioner_Admin_Live_Preview
         </head>
 
         <body <?php body_class(); ?>>
-            <div class="petitioner-preview-wrapper petitioner-preview" style="max-width: 800px; margin: 40px auto; padding: 20px;">
+            <div class="petitioner-preview-wrapper petitioner-preview" style="max-width: 800px; margin: 8px auto; padding: 12px;">
                 <?php
                 if ($form_id) {
                     $frontend_ui = new AV_Petitioner_Frontend_UI();

--- a/inc/admin-ui/settings/class-admin-live-preview.php
+++ b/inc/admin-ui/settings/class-admin-live-preview.php
@@ -155,6 +155,12 @@ class AV_Petitioner_Admin_Live_Preview
     ?>
         <script>
             const adminOrigin = new URL(<?php echo wp_json_encode($admin_url); ?>, window.location.href).origin;
+            // Prevent actual form submission inside the live preview
+            document.addEventListener('submit', function(e) {
+                e.preventDefault();
+                e.stopPropagation();
+            }, true); // Use capture phase to intercept before frontend JS
+
             // Listen for messages from the parent window
             window.addEventListener('message', function(event) {
                 // Verify the message comes from the WordPress admin dashboard

--- a/inc/admin-ui/settings/class-admin-live-preview.php
+++ b/inc/admin-ui/settings/class-admin-live-preview.php
@@ -60,6 +60,11 @@ class AV_Petitioner_Admin_Live_Preview
         if (!is_array($payload)) {
             $payload = [];
         }
+
+        // Sanitize custom CSS to prevent XSS/HTML injection
+        if (isset($payload['custom_css'])) {
+            $payload['custom_css'] = wp_strip_all_tags($payload['custom_css']);
+        }
         
         // Pass payload as overrides to the dynamic CSS generator
         $css = AV_Petitioner_Dynamic_CSS::generate_css($payload);

--- a/inc/admin-ui/settings/class-admin-live-preview.php
+++ b/inc/admin-ui/settings/class-admin-live-preview.php
@@ -90,6 +90,9 @@ class AV_Petitioner_Admin_Live_Preview
         // Prevent clickjacking by ensuring this can only be framed by the same origin
         send_frame_options_header();
 
+        // Prevent aggressive caching plugins/CDNs from caching this admin-only view
+        nocache_headers();
+
         $form_id = isset($_GET['form_id']) ? intval($_GET['form_id']) : 0;
 
         // Remove admin bar for the preview

--- a/inc/admin-ui/settings/class-admin-live-preview.php
+++ b/inc/admin-ui/settings/class-admin-live-preview.php
@@ -61,9 +61,9 @@ class AV_Petitioner_Admin_Live_Preview
             $payload = [];
         }
 
-        // Sanitize custom CSS to prevent XSS/HTML injection
+        // Sanitize custom CSS to prevent XSS/HTML injection while preserving valid CSS chars like <
         if (isset($payload['custom_css'])) {
-            $payload['custom_css'] = wp_strip_all_tags($payload['custom_css']);
+            $payload['custom_css'] = str_ireplace(['<style', '</style>'], '', $payload['custom_css']);
         }
 
         // Pass payload as overrides to the dynamic CSS generator

--- a/inc/admin-ui/settings/class-admin-live-preview.php
+++ b/inc/admin-ui/settings/class-admin-live-preview.php
@@ -4,13 +4,35 @@ if (!defined('ABSPATH')) {
     exit;
 }
 
+/**
+ * Class AV_Petitioner_Admin_Live_Preview
+ * 
+ * Handles the rendering of the live preview iframe on the Visual Settings page.
+ * Uses a bare frontend template via `template_redirect` to ensure active theme 
+ * styles are loaded accurately.
+ *
+ * @since 0.8.5
+ */
 class AV_Petitioner_Admin_Live_Preview
 {
+    /**
+     * Initializes the class and hooks into WordPress.
+     *
+     * @since 0.8.5
+     * @return void
+     */
     public static function init()
     {
         add_action('template_redirect', [self::class, 'render_preview']);
     }
 
+    /**
+     * Renders the bare HTML shell for the live preview iframe.
+     * Triggers via `template_redirect` when `petitioner_live_preview` is set.
+     *
+     * @since 0.8.5
+     * @return void
+     */
     public static function render_preview()
     {
         if (!isset($_GET['petitioner_live_preview'])) {
@@ -65,6 +87,13 @@ class AV_Petitioner_Admin_Live_Preview
         exit;
     }
 
+    /**
+     * Renders the inline JavaScript that listens for `postMessage` events 
+     * to update the form styles and visibility in real-time.
+     *
+     * @since 0.8.5
+     * @return void
+     */
     public static function render_preview_script()
     {
         ?>

--- a/inc/admin-ui/settings/class-admin-live-preview.php
+++ b/inc/admin-ui/settings/class-admin-live-preview.php
@@ -65,10 +65,10 @@ class AV_Petitioner_Admin_Live_Preview
         if (isset($payload['custom_css'])) {
             $payload['custom_css'] = wp_strip_all_tags($payload['custom_css']);
         }
-        
+
         // Pass payload as overrides to the dynamic CSS generator
         $css = AV_Petitioner_Dynamic_CSS::generate_css($payload);
-        
+
         wp_send_json_success(['css' => $css]);
     }
 
@@ -94,16 +94,17 @@ class AV_Petitioner_Admin_Live_Preview
         send_frame_options_header();
 
         $form_id = isset($_GET['form_id']) ? intval($_GET['form_id']) : 0;
-        
+
         // Remove admin bar for the preview
         add_filter('show_admin_bar', '__return_false');
-        
+
         // Add the postMessage listener script to the footer
         add_action('wp_footer', [self::class, 'render_preview_script'], 999);
 
-        ?>
+?>
         <!DOCTYPE html>
         <html <?php language_attributes(); ?>>
+
         <head>
             <meta charset="<?php bloginfo('charset'); ?>">
             <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -111,13 +112,17 @@ class AV_Petitioner_Admin_Live_Preview
             <?php wp_head(); ?>
             <style>
                 body {
-                    background: transparent; 
+                    background: transparent;
                     margin: 0;
                     padding: 20px;
                 }
-                html { margin-top: 0 !important; }
+
+                html {
+                    margin-top: 0 !important;
+                }
             </style>
         </head>
+
         <body <?php body_class(); ?>>
             <div class="petitioner-preview-wrapper petitioner-preview" style="max-width: 800px; margin: 40px auto; padding: 20px;">
                 <?php
@@ -131,8 +136,9 @@ class AV_Petitioner_Admin_Live_Preview
             </div>
             <?php wp_footer(); ?>
         </body>
+
         </html>
-        <?php
+    <?php
         exit;
     }
 
@@ -146,7 +152,7 @@ class AV_Petitioner_Admin_Live_Preview
     public static function render_preview_script()
     {
         $admin_url = admin_url();
-        ?>
+    ?>
         <script>
             const adminOrigin = new URL('<?php echo esc_js($admin_url); ?>', window.location.href).origin;
 
@@ -157,13 +163,14 @@ class AV_Petitioner_Admin_Live_Preview
 
                 if (event.data && event.data.type === 'UPDATE_VISIBILITY') {
                     const payload = event.data.payload;
+                    if (!payload) return;
                     const root = document.querySelector('.petitioner');
                     if (!root) return;
-                    
+
                     // Toggle elements based on settings
                     const titleEl = document.querySelector('.petitioner__title');
                     if (titleEl) titleEl.style.display = payload.show_title ? 'block' : 'none';
-                    
+
                     const letterEl = document.querySelector('.petitioner__btn--letter');
                     if (letterEl) letterEl.style.display = payload.show_letter ? 'block' : 'none';
 
@@ -173,7 +180,7 @@ class AV_Petitioner_Admin_Live_Preview
 
                 if (event.data && event.data.type === 'UPDATE_CSS') {
                     const cssString = event.data.payload;
-                    
+
                     // Apply custom CSS string
                     let customStyleEl = document.getElementById('petitioner-dynamic-css');
                     if (!customStyleEl) {
@@ -185,6 +192,6 @@ class AV_Petitioner_Admin_Live_Preview
                 }
             });
         </script>
-        <?php
+<?php
     }
 }

--- a/inc/admin-ui/settings/class-admin-live-preview.php
+++ b/inc/admin-ui/settings/class-admin-live-preview.php
@@ -24,6 +24,27 @@ class AV_Petitioner_Admin_Live_Preview
     public static function init()
     {
         add_action('template_redirect', [self::class, 'render_preview']);
+        add_action('wp_ajax_petitioner_generate_preview_css', [self::class, 'generate_preview_css']);
+    }
+
+    /**
+     * AJAX handler to generate CSS for the live preview.
+     *
+     * @since 0.8.5
+     * @return void
+     */
+    public static function generate_preview_css()
+    {
+        if (!current_user_can('manage_options')) {
+            wp_send_json_error('Unauthorized');
+        }
+
+        $payload = isset($_POST['payload']) ? (array) $_POST['payload'] : [];
+        
+        // Pass payload as overrides to the dynamic CSS generator
+        $css = AV_Petitioner_Dynamic_CSS::generate_css($payload);
+        
+        wp_send_json_success(['css' => $css]);
     }
 
     /**
@@ -100,7 +121,7 @@ class AV_Petitioner_Admin_Live_Preview
         <script>
             // Listen for messages from the parent window
             window.addEventListener('message', function(event) {
-                if (event.data && event.data.type === 'UPDATE_SETTINGS') {
+                if (event.data && event.data.type === 'UPDATE_VISIBILITY') {
                     const payload = event.data.payload;
                     const root = document.querySelector('.petitioner');
                     if (!root) return;
@@ -114,99 +135,19 @@ class AV_Petitioner_Admin_Live_Preview
 
                     const goalEl = document.querySelector('.petitioner__goal');
                     if (goalEl) goalEl.style.display = payload.show_goal ? 'flex' : 'none';
+                }
 
-                    // Apply custom CSS
-                    let customStyleEl = document.getElementById('preview-custom-css');
+                if (event.data && event.data.type === 'UPDATE_CSS') {
+                    const cssString = event.data.payload;
+                    
+                    // Apply custom CSS string
+                    let customStyleEl = document.getElementById('petitioner-dynamic-css');
                     if (!customStyleEl) {
                         customStyleEl = document.createElement('style');
-                        customStyleEl.id = 'preview-custom-css';
+                        customStyleEl.id = 'petitioner-dynamic-css';
                         document.head.appendChild(customStyleEl);
                     }
-                    customStyleEl.textContent = payload.custom_css || '';
-
-                    const setVar = (name, val) => {
-                        if (val) {
-                            root.style.setProperty(name, val, 'important');
-                        } else {
-                            root.style.removeProperty(name);
-                        }
-                    };
-
-                    // Colors
-                    setVar('--ptr-color-primary', payload.primary_color);
-                    setVar('--ptr-color-dark', payload.dark_color);
-                    setVar('--ptr-color-grey', payload.grey_color);
-
-                    // Border Radius
-                    if (payload.border_radius) {
-                        setVar('--ptr-input-border-radius', `var(--ptr-border-radius-${payload.border_radius})`);
-                        setVar('--ptr-button-border-radius', `var(--ptr-border-radius-${payload.border_radius})`);
-                        
-                        let wrapperRadius = payload.border_radius === 'full' ? 'lg' : payload.border_radius;
-                        setVar('--ptr-wrapper-radius', `var(--ptr-border-radius-${wrapperRadius})`);
-                    } else {
-                        root.style.removeProperty('--ptr-input-border-radius');
-                        root.style.removeProperty('--ptr-button-border-radius');
-                        root.style.removeProperty('--ptr-wrapper-radius');
-                    }
-
-                    // Base Font Size
-                    if (payload.base_font_size) {
-                        setVar('--ptr-label-font-size', `var(--ptr-fs-${payload.base_font_size})`);
-                    } else {
-                        root.style.removeProperty('--ptr-label-font-size');
-                    }
-
-                    // Button Font Size
-                    if (payload.button_font_size) {
-                        setVar('--ptr-btn-font-size', `var(--ptr-fs-${payload.button_font_size})`);
-                    } else {
-                        root.style.removeProperty('--ptr-btn-font-size');
-                    }
-
-                    // Spacing
-                    if (payload.field_spacing) {
-                        setVar('--ptr-input-margin-bottom', `var(--ptr-spacer-${payload.field_spacing})`);
-                    } else {
-                        root.style.removeProperty('--ptr-input-margin-bottom');
-                    }
-
-                    // Border width
-                    if (payload.input_border_width) {
-                        setVar('--ptr-input-border-width', payload.input_border_width);
-                    } else {
-                        root.style.removeProperty('--ptr-input-border-width');
-                    }
-
-                    // Input Size
-                    if (payload.input_size) {
-                        switch(payload.input_size) {
-                            case 'sm':
-                                setVar('--ptr-input-line-height', '24px');
-                                setVar('--ptr-input-spacing-y', '4px');
-                                setVar('--ptr-label-line-height', '1.4');
-                                break;
-                            case 'md':
-                                setVar('--ptr-input-line-height', '24px');
-                                setVar('--ptr-input-spacing-y', '8px');
-                                root.style.removeProperty('--ptr-label-line-height');
-                                break;
-                            case 'lg':
-                                setVar('--ptr-input-line-height', '32px');
-                                setVar('--ptr-input-spacing-y', '8px');
-                                root.style.removeProperty('--ptr-label-line-height');
-                                break;
-                            case 'xl':
-                                setVar('--ptr-input-line-height', '40px');
-                                setVar('--ptr-input-spacing-y', '0.7rem');
-                                root.style.removeProperty('--ptr-label-line-height');
-                                break;
-                        }
-                    } else {
-                        root.style.removeProperty('--ptr-input-line-height');
-                        root.style.removeProperty('--ptr-input-spacing-y');
-                        root.style.removeProperty('--ptr-label-line-height');
-                    }
+                    customStyleEl.textContent = cssString || '';
                 }
             });
         </script>

--- a/inc/admin-ui/settings/class-admin-live-preview.php
+++ b/inc/admin-ui/settings/class-admin-live-preview.php
@@ -124,7 +124,7 @@ class AV_Petitioner_Admin_Live_Preview
         </head>
 
         <body <?php body_class(); ?>>
-            <div class="petitioner-preview-wrapper petitioner-preview" style="max-width: 800px; margin: 8px auto; padding: 12px;">
+            <div class="petitioner-preview-wrapper petitioner-preview" style="max-width: 600px; margin: 8px auto; padding: 12px;">
                 <?php
                 if ($form_id) {
                     $frontend_ui = new AV_Petitioner_Frontend_UI();

--- a/inc/admin-ui/settings/class-admin-live-preview.php
+++ b/inc/admin-ui/settings/class-admin-live-preview.php
@@ -50,13 +50,20 @@ class AV_Petitioner_Admin_Live_Preview
         </head>
         <body>
             <?php
-            $petitions = get_posts([
-                'post_type' => 'petitioner-petition',
-                'posts_per_page' => 1,
-                'post_status' => 'any'
-            ]);
+            $form_id = isset($_GET['form_id']) ? intval($_GET['form_id']) : 0;
+            $petitions = [];
 
-            if (!empty($petitions)) {
+            if ($form_id) {
+                $petitions = [get_post($form_id)];
+            } else {
+                $petitions = get_posts([
+                    'post_type' => 'petitioner-petition',
+                    'posts_per_page' => 1,
+                    'post_status' => 'any'
+                ]);
+            }
+
+            if (!empty($petitions) && $petitions[0]) {
                 $frontend_ui = new AV_Petitioner_Frontend_UI();
                 echo $frontend_ui->display_form(['id' => $petitions[0]->ID]);
             } else {

--- a/inc/admin-ui/settings/class-admin-live-preview.php
+++ b/inc/admin-ui/settings/class-admin-live-preview.php
@@ -151,12 +151,14 @@ class AV_Petitioner_Admin_Live_Preview
      */
     public static function render_preview_script()
     {
+        $admin_url = admin_url();
     ?>
         <script>
+            const adminOrigin = new URL('<?php echo esc_js($admin_url); ?>', window.location.href).origin;
             // Listen for messages from the parent window
             window.addEventListener('message', function(event) {
                 // Verify the message comes from the WordPress admin dashboard
-                if (event.origin !== window.location.origin) return;
+                if (event.origin !== adminOrigin) return;
 
                 if (event.data && event.data.type === 'UPDATE_VISIBILITY') {
                     const payload = event.data.payload;

--- a/inc/admin-ui/settings/class-admin-live-preview.php
+++ b/inc/admin-ui/settings/class-admin-live-preview.php
@@ -83,9 +83,11 @@ class AV_Petitioner_Admin_Live_Preview
             return;
         }
 
-        // Only allow admins
+        // Only allow admins to see the preview. 
+        // If unauthorized, we simply return and let the normal homepage load. 
+        // This prevents a 403 from being accidentally cached as the homepage by aggressive caching plugins.
         if (!current_user_can('manage_options')) {
-            wp_die('Unauthorized', 403);
+            return;
         }
 
         // Prevent clickjacking by ensuring this can only be framed by the same origin

--- a/inc/admin-ui/settings/class-admin-live-preview.php
+++ b/inc/admin-ui/settings/class-admin-live-preview.php
@@ -154,7 +154,7 @@ class AV_Petitioner_Admin_Live_Preview
         $admin_url = admin_url();
     ?>
         <script>
-            const adminOrigin = new URL('<?php echo esc_js($admin_url); ?>', window.location.href).origin;
+            const adminOrigin = new URL(<?php echo wp_json_encode($admin_url); ?>, window.location.href).origin;
             // Listen for messages from the parent window
             window.addEventListener('message', function(event) {
                 // Verify the message comes from the WordPress admin dashboard

--- a/inc/admin-ui/settings/class-admin-live-preview.php
+++ b/inc/admin-ui/settings/class-admin-live-preview.php
@@ -39,6 +39,8 @@ class AV_Petitioner_Admin_Live_Preview
             wp_send_json_error('Unauthorized');
         }
 
+        check_ajax_referer('petitioner_nonce', 'petitioner_nonce');
+
         $payload = isset($_POST['payload']) ? (array) $_POST['payload'] : [];
         
         // Pass payload as overrides to the dynamic CSS generator

--- a/inc/admin-ui/settings/class-admin-live-preview.php
+++ b/inc/admin-ui/settings/class-admin-live-preview.php
@@ -15,6 +15,8 @@ if (!defined('ABSPATH')) {
  */
 class AV_Petitioner_Admin_Live_Preview
 {
+    const NONCE_ACTION = 'petitioner_generate_preview_css';
+
     /**
      * Initializes the class and hooks into WordPress.
      *
@@ -25,6 +27,19 @@ class AV_Petitioner_Admin_Live_Preview
     {
         add_action('template_redirect', [self::class, 'render_preview']);
         add_action('wp_ajax_petitioner_generate_preview_css', [self::class, 'generate_preview_css']);
+        add_filter('av_petitioner_info_settings', [self::class, 'add_preview_nonce']);
+    }
+
+    /**
+     * Injects the dedicated preview nonce into the localized settings data.
+     *
+     * @param array $petitioner_info
+     * @return array
+     */
+    public static function add_preview_nonce($petitioner_info)
+    {
+        $petitioner_info['preview_nonce'] = wp_create_nonce(self::NONCE_ACTION);
+        return $petitioner_info;
     }
 
     /**
@@ -39,7 +54,7 @@ class AV_Petitioner_Admin_Live_Preview
             wp_send_json_error('Unauthorized');
         }
 
-        check_ajax_referer('petitioner_nonce', 'petitioner_nonce');
+        check_ajax_referer(self::NONCE_ACTION, 'petitioner_nonce');
 
         $payload = isset($_POST['payload']) ? (array) $_POST['payload'] : [];
         

--- a/inc/admin-ui/settings/class-admin-live-preview.php
+++ b/inc/admin-ui/settings/class-admin-live-preview.php
@@ -61,13 +61,11 @@ class AV_Petitioner_Admin_Live_Preview
             $payload = [];
         }
 
-        // Sanitize custom CSS to prevent XSS/HTML injection while preserving valid CSS chars like <
-        if (isset($payload['custom_css'])) {
-            $payload['custom_css'] = str_ireplace(['<style', '</style>'], '', $payload['custom_css']);
-        }
-
         // Pass payload as overrides to the dynamic CSS generator
         $css = AV_Petitioner_Dynamic_CSS::generate_css($payload);
+
+        // Sanitize the final CSS to prevent XSS/HTML injection while preserving valid CSS chars like <
+        $css = preg_replace('#<\s*/?\s*style[^>]*>#is', '', $css);
 
         wp_send_json_success(['css' => $css]);
     }

--- a/inc/admin-ui/settings/class-admin-live-preview.php
+++ b/inc/admin-ui/settings/class-admin-live-preview.php
@@ -67,6 +67,9 @@ class AV_Petitioner_Admin_Live_Preview
             wp_die('Unauthorized', 403);
         }
 
+        // Prevent clickjacking by ensuring this can only be framed by the same origin
+        send_frame_options_header();
+
         $form_id = isset($_GET['form_id']) ? intval($_GET['form_id']) : 0;
         
         // Remove admin bar for the preview
@@ -119,10 +122,16 @@ class AV_Petitioner_Admin_Live_Preview
      */
     public static function render_preview_script()
     {
+        $admin_url = admin_url();
         ?>
         <script>
+            const adminOrigin = new URL('<?php echo esc_js($admin_url); ?>', window.location.href).origin;
+
             // Listen for messages from the parent window
             window.addEventListener('message', function(event) {
+                // Verify the message comes from the WordPress admin dashboard
+                if (event.origin !== adminOrigin) return;
+
                 if (event.data && event.data.type === 'UPDATE_VISIBILITY') {
                     const payload = event.data.payload;
                     const root = document.querySelector('.petitioner');

--- a/inc/admin-ui/settings/class-admin-settings-ui.php
+++ b/inc/admin-ui/settings/class-admin-settings-ui.php
@@ -158,10 +158,27 @@ class AV_Petitioner_Admin_Settings_UI
             } else {
                 $petitioner_info[$key] = $option_values[$key];
             }
+        }
+        
+        $petitions = get_posts([
+            'post_type' => 'petitioner-petition',
+            'posts_per_page' => -1,
+            'post_status' => 'any'
+        ]);
+        $petition_list = [];
+        foreach ($petitions as $p) {
+            $petition_list[] = [
+                'id' => $p->ID,
+                'title' => !empty($p->post_title) ? $p->post_title : __('(No Title)', 'petitioner')
+            ];
+        }
+
         $petitioner_info['default_values'] = [
             "colors" => $this->default_colors,
             "labels" => $this->get_default_labels()
         ];
+        
+        $petitioner_info['petitions'] = $petition_list;
 
         /**
          * Filter to modify petitioner data that is sent to the edit screen

--- a/inc/admin-ui/settings/class-admin-settings-ui.php
+++ b/inc/admin-ui/settings/class-admin-settings-ui.php
@@ -59,9 +59,6 @@ class AV_Petitioner_Admin_Settings_UI
                 wp_enqueue_code_editor(array('type' => 'text/css'));
                 wp_enqueue_script('wp-theme-plugin-editor');
                 wp_enqueue_style('wp-codemirror');
-                wp_add_inline_script('wp-theme-plugin-editor', "jQuery(document).ready(function($) {
-                    wp.codeEditor.initialize($('#petitionerCode'), {type: 'text/css'});
-                });", true);
 
                 wp_enqueue_style('wp-color-picker');
                 wp_enqueue_script('wp-color-picker');

--- a/inc/admin-ui/settings/class-admin-settings-ui.php
+++ b/inc/admin-ui/settings/class-admin-settings-ui.php
@@ -163,6 +163,8 @@ class AV_Petitioner_Admin_Settings_UI
             "colors" => $this->default_colors,
             "labels" => $this->get_default_labels()
         ];
+        
+        $petitioner_info['home_url'] = home_url('/');
 
         /**
          * Filter to modify petitioner data that is sent to the edit screen

--- a/inc/admin-ui/settings/class-admin-settings-ui.php
+++ b/inc/admin-ui/settings/class-admin-settings-ui.php
@@ -159,26 +159,10 @@ class AV_Petitioner_Admin_Settings_UI
                 $petitioner_info[$key] = $option_values[$key];
             }
         }
-        
-        $petitions = get_posts([
-            'post_type' => 'petitioner-petition',
-            'posts_per_page' => -1,
-            'post_status' => 'any'
-        ]);
-        $petition_list = [];
-        foreach ($petitions as $p) {
-            $petition_list[] = [
-                'id' => $p->ID,
-                'title' => !empty($p->post_title) ? $p->post_title : __('(No Title)', 'petitioner')
-            ];
-        }
-
         $petitioner_info['default_values'] = [
             "colors" => $this->default_colors,
             "labels" => $this->get_default_labels()
         ];
-        
-        $petitioner_info['petitions'] = $petition_list;
 
         /**
          * Filter to modify petitioner data that is sent to the edit screen

--- a/inc/admin-ui/settings/class-admin-settings-ui.php
+++ b/inc/admin-ui/settings/class-admin-settings-ui.php
@@ -158,8 +158,6 @@ class AV_Petitioner_Admin_Settings_UI
             } else {
                 $petitioner_info[$key] = $option_values[$key];
             }
-        }
-
         $petitioner_info['default_values'] = [
             "colors" => $this->default_colors,
             "labels" => $this->get_default_labels()

--- a/inc/class-setup.php
+++ b/inc/class-setup.php
@@ -208,7 +208,7 @@ class AV_Petitioner_Setup
 
         if (!empty($custom_css)) {
             // Sanitize the final CSS to prevent XSS/HTML injection while preserving valid CSS chars like <
-            $custom_css = preg_replace('#<\s*/?\s*style[^>]*>#is', '', $custom_css);
+            $custom_css = preg_replace('#<\s*/?\s*style\b[^>]*>?#is', '', $custom_css);
             wp_add_inline_style('petitioner-style', $custom_css);
         }
 

--- a/inc/class-setup.php
+++ b/inc/class-setup.php
@@ -47,6 +47,10 @@ class AV_Petitioner_Setup
                 new AV_Petitioner_Admin_Component_Preview_UI();
             }
 
+            if (class_exists('AV_Petitioner_Admin_Live_Preview')) {
+                AV_Petitioner_Admin_Live_Preview::init();
+            }
+
             // shared admin settings
             if (class_exists('AV_Petitioner_Admin_Shared')) {
                 new AV_Petitioner_Admin_Shared();

--- a/inc/class-setup.php
+++ b/inc/class-setup.php
@@ -233,22 +233,75 @@ class AV_Petitioner_Setup
         $dark_color = get_option('petitioner_dark_color', '');
         $grey_color = get_option('petitioner_grey_color', '');
 
-        $default_colors = '';
+        $border_radius = get_option('petitioner_border_radius', '');
+        $base_font_size = get_option('petitioner_base_font_size', '');
+        $button_font_size = get_option('petitioner_button_font_size', '');
+        $field_spacing = get_option('petitioner_field_spacing', '');
+        $input_border_width = get_option('petitioner_input_border_width', '');
+        $input_size = get_option('petitioner_input_size', '');
+
+        $dynamic_styles = '';
 
         if (!empty($primary_color)) {
-            $default_colors .= '--ptr-color-primary: ' . $primary_color . '!important;';
+            $dynamic_styles .= '--ptr-color-primary: ' . $primary_color . '!important;';
         }
 
         if (!empty($dark_color)) {
-            $default_colors .= '--ptr-color-dark: ' . $dark_color . '!important;';
+            $dynamic_styles .= '--ptr-color-dark: ' . $dark_color . '!important;';
         }
 
         if (!empty($grey_color)) {
-            $default_colors .= '--ptr-color-grey: ' . $grey_color . '!important;';
+            $dynamic_styles .= '--ptr-color-grey: ' . $grey_color . '!important;';
         }
 
-        if (!empty($default_colors)) {
-            $custom_css .= '.petitioner {' . $default_colors . ' } ';
+        if (!empty($border_radius)) {
+            $dynamic_styles .= '--ptr-input-border-radius: var(--ptr-border-radius-' . $border_radius . ')!important;';
+            $dynamic_styles .= '--ptr-button-border-radius: var(--ptr-border-radius-' . $border_radius . ')!important;';
+            
+            // Limit wrapper radius to 'lg' so it doesn't become a pill
+            $wrapper_radius = $border_radius === 'full' ? 'lg' : $border_radius;
+            $dynamic_styles .= '--ptr-wrapper-radius: var(--ptr-border-radius-' . $wrapper_radius . ')!important;';
+        }
+
+        if (!empty($base_font_size)) {
+            $dynamic_styles .= '--ptr-label-font-size: var(--ptr-fs-' . $base_font_size . ')!important;';
+        }
+
+        if (!empty($button_font_size)) {
+            $dynamic_styles .= '--ptr-btn-font-size: var(--ptr-fs-' . $button_font_size . ')!important;';
+        }
+
+        if (!empty($field_spacing)) {
+            $dynamic_styles .= '--ptr-input-margin-bottom: var(--ptr-spacer-' . $field_spacing . ')!important;';
+        }
+
+        if (!empty($input_border_width)) {
+            $dynamic_styles .= '--ptr-input-border-width: ' . $input_border_width . '!important;';
+        }
+
+        if ($input_size === 'sm') {
+            $dynamic_styles .= '--ptr-input-line-height: 24px !important;';
+            $dynamic_styles .= '--ptr-input-spacing-y: 4px !important;';
+            $dynamic_styles .= '--ptr-label-line-height: 1.4 !important;';
+        }
+
+        if ($input_size === 'md') {
+            $dynamic_styles .= '--ptr-input-line-height: 24px !important;';
+            $dynamic_styles .= '--ptr-input-spacing-y: 8px !important;';
+        }
+
+        if ($input_size === 'lg') {
+            $dynamic_styles .= '--ptr-input-line-height: 32px !important;';
+            $dynamic_styles .= '--ptr-input-spacing-y: 8px !important;';
+        }
+
+        if ($input_size === 'xl') {
+            $dynamic_styles .= '--ptr-input-line-height: 40px !important;';
+            $dynamic_styles .= '--ptr-input-spacing-y: 0.7rem !important;';
+        }
+
+        if (!empty($dynamic_styles)) {
+            $custom_css .= '.petitioner {' . $dynamic_styles . ' } ';
         }
 
         $custom_css .= get_option('petitioner_custom_css', '');

--- a/inc/class-setup.php
+++ b/inc/class-setup.php
@@ -207,7 +207,9 @@ class AV_Petitioner_Setup
         $custom_css = AV_Petitioner_Dynamic_CSS::generate_css();
 
         if (!empty($custom_css)) {
-            wp_add_inline_style('petitioner-style', str_ireplace( [ '<style', '</style>' ], '', $custom_css ));
+            // Sanitize the final CSS to prevent XSS/HTML injection while preserving valid CSS chars like <
+            $custom_css = preg_replace('#<\s*/?\s*style[^>]*>#is', '', $custom_css);
+            wp_add_inline_style('petitioner-style', $custom_css);
         }
 
         wp_register_script('petitioner-script', plugin_dir_url(dirname(__FILE__)) . 'dist/main.js', [], AV_PETITIONER_PLUGIN_VERSION, true);

--- a/inc/class-setup.php
+++ b/inc/class-setup.php
@@ -57,6 +57,11 @@ class AV_Petitioner_Setup
                 new AV_Petitioner_Label_Overrides();
             }
 
+            // dynamic css
+            if (class_exists('AV_Petitioner_Dynamic_CSS')) {
+                AV_Petitioner_Dynamic_CSS::init();
+            }
+
             // custom properties
             if (class_exists('AV_Petitioner_Custom_Properties')) {
                 new AV_Petitioner_Custom_Properties();

--- a/inc/class-setup.php
+++ b/inc/class-setup.php
@@ -207,7 +207,7 @@ class AV_Petitioner_Setup
         $custom_css = AV_Petitioner_Dynamic_CSS::generate_css();
 
         if (!empty($custom_css)) {
-            wp_add_inline_style('petitioner-style', wp_strip_all_tags($custom_css));
+            wp_add_inline_style('petitioner-style', str_ireplace( [ '<style', '</style>' ], '', $custom_css ));
         }
 
         wp_register_script('petitioner-script', plugin_dir_url(dirname(__FILE__)) . 'dist/main.js', [], AV_PETITIONER_PLUGIN_VERSION, true);

--- a/inc/class-setup.php
+++ b/inc/class-setup.php
@@ -257,7 +257,7 @@ class AV_Petitioner_Setup
         }
 
         wp_enqueue_style('petitioner-admin-style', plugin_dir_url(dirname(__FILE__)) . 'dist/admin.css', array(), AV_PETITIONER_PLUGIN_VERSION);
-        wp_enqueue_script('petitioner-admin-script', plugin_dir_url(dirname(__FILE__)) . 'dist/admin.js', ['wp-blocks', 'wp-block-editor', 'wp-element', 'wp-components', 'wp-data', 'wp-i18n', 'wp-hooks'], AV_PETITIONER_PLUGIN_VERSION, true);
+        wp_enqueue_script('petitioner-admin-script', plugin_dir_url(dirname(__FILE__)) . 'dist/admin.js', ['wp-blocks', 'wp-block-editor', 'wp-element', 'wp-components', 'wp-data', 'wp-core-data', 'wp-i18n', 'wp-hooks'], AV_PETITIONER_PLUGIN_VERSION, true);
 
         wp_localize_script('petitioner-admin-script', 'petitionerFormSettings', [
             'actionPath' => admin_url('admin-ajax.php') . '?action=petitioner_form_submit',

--- a/inc/class-setup.php
+++ b/inc/class-setup.php
@@ -195,7 +195,7 @@ class AV_Petitioner_Setup
         wp_enqueue_style('petitioner-style', plugin_dir_url(dirname(__FILE__)) . 'dist/main.css', array(), AV_PETITIONER_PLUGIN_VERSION);
 
         // Custom CSS styles
-        $custom_css = $this->generate_custom_css();
+        $custom_css = AV_Petitioner_Dynamic_CSS::generate_css();
 
         if (!empty($custom_css)) {
             wp_add_inline_style('petitioner-style', wp_strip_all_tags($custom_css));
@@ -226,88 +226,6 @@ class AV_Petitioner_Setup
     }
 
 
-    public function generate_custom_css()
-    {
-        $custom_css = '';
-        $primary_color = get_option('petitioner_primary_color', '');
-        $dark_color = get_option('petitioner_dark_color', '');
-        $grey_color = get_option('petitioner_grey_color', '');
-
-        $border_radius = get_option('petitioner_border_radius', '');
-        $base_font_size = get_option('petitioner_base_font_size', '');
-        $button_font_size = get_option('petitioner_button_font_size', '');
-        $field_spacing = get_option('petitioner_field_spacing', '');
-        $input_border_width = get_option('petitioner_input_border_width', '');
-        $input_size = get_option('petitioner_input_size', '');
-
-        $dynamic_styles = '';
-
-        if (!empty($primary_color)) {
-            $dynamic_styles .= '--ptr-color-primary: ' . $primary_color . '!important;';
-        }
-
-        if (!empty($dark_color)) {
-            $dynamic_styles .= '--ptr-color-dark: ' . $dark_color . '!important;';
-        }
-
-        if (!empty($grey_color)) {
-            $dynamic_styles .= '--ptr-color-grey: ' . $grey_color . '!important;';
-        }
-
-        if (!empty($border_radius)) {
-            $dynamic_styles .= '--ptr-input-border-radius: var(--ptr-border-radius-' . $border_radius . ')!important;';
-            $dynamic_styles .= '--ptr-button-border-radius: var(--ptr-border-radius-' . $border_radius . ')!important;';
-            
-            // Limit wrapper radius to 'lg' so it doesn't become a pill
-            $wrapper_radius = $border_radius === 'full' ? 'lg' : $border_radius;
-            $dynamic_styles .= '--ptr-wrapper-radius: var(--ptr-border-radius-' . $wrapper_radius . ')!important;';
-        }
-
-        if (!empty($base_font_size)) {
-            $dynamic_styles .= '--ptr-label-font-size: var(--ptr-fs-' . $base_font_size . ')!important;';
-        }
-
-        if (!empty($button_font_size)) {
-            $dynamic_styles .= '--ptr-btn-font-size: var(--ptr-fs-' . $button_font_size . ')!important;';
-        }
-
-        if (!empty($field_spacing)) {
-            $dynamic_styles .= '--ptr-input-margin-bottom: var(--ptr-spacer-' . $field_spacing . ')!important;';
-        }
-
-        if (!empty($input_border_width)) {
-            $dynamic_styles .= '--ptr-input-border-width: ' . $input_border_width . '!important;';
-        }
-
-        if ($input_size === 'sm') {
-            $dynamic_styles .= '--ptr-input-line-height: 24px !important;';
-            $dynamic_styles .= '--ptr-input-spacing-y: 4px !important;';
-            $dynamic_styles .= '--ptr-label-line-height: 1.4 !important;';
-        }
-
-        if ($input_size === 'md') {
-            $dynamic_styles .= '--ptr-input-line-height: 24px !important;';
-            $dynamic_styles .= '--ptr-input-spacing-y: 8px !important;';
-        }
-
-        if ($input_size === 'lg') {
-            $dynamic_styles .= '--ptr-input-line-height: 32px !important;';
-            $dynamic_styles .= '--ptr-input-spacing-y: 8px !important;';
-        }
-
-        if ($input_size === 'xl') {
-            $dynamic_styles .= '--ptr-input-line-height: 40px !important;';
-            $dynamic_styles .= '--ptr-input-spacing-y: 0.7rem !important;';
-        }
-
-        if (!empty($dynamic_styles)) {
-            $custom_css .= '.petitioner {' . $dynamic_styles . ' } ';
-        }
-
-        $custom_css .= get_option('petitioner_custom_css', '');
-
-        return $custom_css;
-    }
 
     /**
      * Enqueue admin scripts and styles.

--- a/inc/class-setup.php
+++ b/inc/class-setup.php
@@ -198,7 +198,7 @@ class AV_Petitioner_Setup
         $custom_css = $this->generate_custom_css();
 
         if (!empty($custom_css)) {
-            wp_add_inline_style('petitioner-style', esc_html(wp_strip_all_tags($custom_css)));
+            wp_add_inline_style('petitioner-style', wp_strip_all_tags($custom_css));
         }
 
         wp_register_script('petitioner-script', plugin_dir_url(dirname(__FILE__)) . 'dist/main.js', [], AV_PETITIONER_PLUGIN_VERSION, true);

--- a/inc/class-setup.php
+++ b/inc/class-setup.php
@@ -256,7 +256,6 @@ class AV_Petitioner_Setup
             wp_enqueue_style('wp-components');
         }
 
-        wp_enqueue_style('petitioner-admin-style', plugin_dir_url(dirname(__FILE__)) . 'dist/admin.css', array(), AV_PETITIONER_PLUGIN_VERSION);
         wp_enqueue_script('petitioner-admin-script', plugin_dir_url(dirname(__FILE__)) . 'dist/admin.js', ['wp-blocks', 'wp-block-editor', 'wp-element', 'wp-components', 'wp-data', 'wp-core-data', 'wp-i18n', 'wp-hooks'], AV_PETITIONER_PLUGIN_VERSION, true);
 
         wp_localize_script('petitioner-admin-script', 'petitionerFormSettings', [

--- a/inc/class-setup.php
+++ b/inc/class-setup.php
@@ -207,8 +207,6 @@ class AV_Petitioner_Setup
         $custom_css = AV_Petitioner_Dynamic_CSS::generate_css();
 
         if (!empty($custom_css)) {
-            // Sanitize the final CSS to prevent XSS/HTML injection while preserving valid CSS chars like <
-            $custom_css = preg_replace('#<\s*/?\s*style\b[^>]*>?#is', '', $custom_css);
             wp_add_inline_style('petitioner-style', $custom_css);
         }
 

--- a/inc/frontend/class-dynamic-css.php
+++ b/inc/frontend/class-dynamic-css.php
@@ -14,9 +14,105 @@ if (!defined('ABSPATH')) {
  */
 class AV_Petitioner_Dynamic_CSS
 {
-    const ALLOWED_SIZES = ['xs', 'sm', 'md', 'lg', 'xl', 'full'];
-    const ALLOWED_BORDER_WIDTHS = ['0px', '1px', '2px', '3px'];
+    /**
+     * Initializes the class and hooks into WordPress.
+     *
+     * @return void
+     */
+    public static function init()
+    {
+        add_filter('av_petitioner_info_settings', [self::class, 'inject_schema_options']);
+    }
 
+    /**
+     * Injects the visual options schema into the localized settings array.
+     *
+     * @param array $settings The frontend settings array.
+     * @return array Modified settings array.
+     */
+    public static function inject_schema_options($settings)
+    {
+        if (!isset($settings['default_values'])) {
+            $settings['default_values'] = [];
+        }
+        $settings['default_values']['visual_options'] = self::get_schema_options();
+        return $settings;
+    }
+
+    /**
+     * Retrieves the schema for available visual options.
+     *
+     * @return array List of available options for dropdowns.
+     */
+    public static function get_schema_options()
+    {
+        static $schema = null;
+
+        if ($schema !== null) {
+            return $schema;
+        }
+
+        $schema = [
+            'border_radius' => [
+                ''     => __('Default (8px)', 'petitioner'),
+                'xs'   => __('Sharp (2px)', 'petitioner'),
+                'sm'   => __('Slightly Rounded (4px)', 'petitioner'),
+                'md'   => __('Rounded (8px)', 'petitioner'),
+                'lg'   => __('Very Rounded (16px)', 'petitioner'),
+                'full' => __('Pill (999px)', 'petitioner'),
+            ],
+            'base_font_size' => [
+                ''   => __('Default (14px)', 'petitioner'),
+                'xs' => __('Extra Small (12px)', 'petitioner'),
+                'sm' => __('Small (14px)', 'petitioner'),
+                'md' => __('Medium (16px)', 'petitioner'),
+            ],
+            'button_font_size' => [
+                ''   => __('Default (18px)', 'petitioner'),
+                'xs' => __('Extra Small (12px)', 'petitioner'),
+                'sm' => __('Small (14px)', 'petitioner'),
+                'md' => __('Medium (16px)', 'petitioner'),
+                'lg' => __('Large (18px)', 'petitioner'),
+            ],
+            'input_border_width' => [
+                ''    => __('Default', 'petitioner'),
+                '0px' => __('0px (None)', 'petitioner'),
+                '1px' => __('1px', 'petitioner'),
+                '2px' => __('2px', 'petitioner'),
+                '3px' => __('3px', 'petitioner'),
+            ],
+            'field_spacing' => [
+                ''   => __('Default (8px)', 'petitioner'),
+                'xs' => __('Extra Small (4px)', 'petitioner'),
+                'sm' => __('Small (8px)', 'petitioner'),
+                'md' => __('Medium (16px)', 'petitioner'),
+                'lg' => __('Large (24px)', 'petitioner'),
+                'xl' => __('Extra Large (32px)', 'petitioner'),
+            ],
+            'input_size' => [
+                ''   => __('Default (~62px)', 'petitioner'),
+                'sm' => __('Small (32px)', 'petitioner'),
+                'md' => __('Regular (40px)', 'petitioner'),
+                'lg' => __('Large (48px)', 'petitioner'),
+                'xl' => __('Extra Large (~62px)', 'petitioner'),
+            ],
+        ];
+
+        /**
+         * Filters the schema for visual options.
+         *
+         * @param array $schema The default schema options.
+         */
+        $schema = apply_filters('av_petitioner_visual_options_schema', $schema);
+
+        return $schema;
+    }
+
+    /**
+     * Generates all dynamic CSS styles based on saved options.
+     *
+     * @return string The generated CSS string.
+     */
     public static function generate_css()
     {
         $dynamic_styles = '';
@@ -37,10 +133,15 @@ class AV_Petitioner_Dynamic_CSS
         return $custom_css;
     }
 
+    /**
+     * Generates CSS variables for color settings.
+     *
+     * @return string The color CSS styles.
+     */
     private static function get_color_styles()
     {
         $styles = '';
-        
+
         $primary = sanitize_hex_color(get_option('petitioner_primary_color', ''));
         if (!empty($primary)) {
             $styles .= '--ptr-color-primary: ' . $primary . '!important;';
@@ -59,15 +160,21 @@ class AV_Petitioner_Dynamic_CSS
         return $styles;
     }
 
+    /**
+     * Generates CSS variables for border radius settings.
+     *
+     * @return string The border radius CSS styles.
+     */
     private static function get_border_radius_styles()
     {
         $styles = '';
         $radius = get_option('petitioner_border_radius', '');
 
-        if (!empty($radius) && in_array($radius, self::ALLOWED_SIZES, true)) {
+        $schema = self::get_schema_options();
+        if (!empty($radius) && array_key_exists($radius, $schema['border_radius'])) {
             $styles .= '--ptr-input-border-radius: var(--ptr-border-radius-' . $radius . ')!important;';
             $styles .= '--ptr-button-border-radius: var(--ptr-border-radius-' . $radius . ')!important;';
-            
+
             // Limit wrapper radius to 'lg' so it doesn't become a pill
             $wrapper = $radius === 'full' ? 'lg' : $radius;
             $styles .= '--ptr-wrapper-radius: var(--ptr-border-radius-' . $wrapper . ')!important;';
@@ -76,51 +183,79 @@ class AV_Petitioner_Dynamic_CSS
         return $styles;
     }
 
+    /**
+     * Generates CSS variables for font size settings.
+     *
+     * @return string The font size CSS styles.
+     */
     private static function get_font_styles()
     {
         $styles = '';
-        
+
         $base = get_option('petitioner_base_font_size', '');
-        if (!empty($base) && in_array($base, self::ALLOWED_SIZES, true)) {
+        $schema = self::get_schema_options();
+        if (!empty($base) && array_key_exists($base, $schema['base_font_size'])) {
             $styles .= '--ptr-label-font-size: var(--ptr-fs-' . $base . ')!important;';
         }
 
         $btn = get_option('petitioner_button_font_size', '');
-        if (!empty($btn) && in_array($btn, self::ALLOWED_SIZES, true)) {
+        if (!empty($btn) && array_key_exists($btn, $schema['button_font_size'])) {
             $styles .= '--ptr-btn-font-size: var(--ptr-fs-' . $btn . ')!important;';
         }
 
         return $styles;
     }
 
+    /**
+     * Generates CSS variables for field spacing settings.
+     *
+     * @return string The field spacing CSS styles.
+     */
     private static function get_spacing_styles()
     {
         $styles = '';
         $spacing = get_option('petitioner_field_spacing', '');
 
-        if (!empty($spacing) && in_array($spacing, self::ALLOWED_SIZES, true)) {
+        $schema = self::get_schema_options();
+        if (!empty($spacing) && array_key_exists($spacing, $schema['field_spacing'])) {
             $styles .= '--ptr-input-margin-bottom: var(--ptr-spacer-' . $spacing . ')!important;';
         }
 
         return $styles;
     }
 
+    /**
+     * Generates CSS variables for input border width settings.
+     *
+     * @return string The input border width CSS styles.
+     */
     private static function get_border_styles()
     {
         $styles = '';
         $width = get_option('petitioner_input_border_width', '');
 
-        if (!empty($width) && in_array($width, self::ALLOWED_BORDER_WIDTHS, true)) {
+        $schema = self::get_schema_options();
+        if (!empty($width) && array_key_exists($width, $schema['input_border_width'])) {
             $styles .= '--ptr-input-border-width: ' . $width . '!important;';
         }
 
         return $styles;
     }
 
+    /**
+     * Generates CSS variables for input size settings.
+     *
+     * @return string The input size CSS styles.
+     */
     private static function get_input_size_styles()
     {
         $styles = '';
         $size = get_option('petitioner_input_size', '');
+
+        $schema = self::get_schema_options();
+        if (!empty($size) && !array_key_exists($size, $schema['input_size'])) {
+            return $styles;
+        }
 
         switch ($size) {
             case 'sm':

--- a/inc/frontend/class-dynamic-css.php
+++ b/inc/frontend/class-dynamic-css.php
@@ -136,26 +136,43 @@ class AV_Petitioner_Dynamic_CSS
     }
 
     /**
-     * Generates all dynamic CSS styles based on saved options.
+     * Helper to get a setting either from overrides or the database.
      *
+     * @param string $key The database option key.
+     * @param array $overrides Optional array of values keyed without the petitioner_ prefix.
+     * @return mixed
+     */
+    private static function get_setting($key, $overrides = [])
+    {
+        $override_key = str_replace('petitioner_', '', $key);
+        if (isset($overrides[$override_key])) {
+            return $overrides[$override_key];
+        }
+        return get_option($key, '');
+    }
+
+    /**
+     * Generates all dynamic CSS styles based on saved options or overrides.
+     *
+     * @param array $overrides Optional overrides for live preview.
      * @return string The generated CSS string.
      */
-    public static function generate_css()
+    public static function generate_css($overrides = [])
     {
         $dynamic_styles = '';
-        $dynamic_styles .= self::get_color_styles();
-        $dynamic_styles .= self::get_border_radius_styles();
-        $dynamic_styles .= self::get_font_styles();
-        $dynamic_styles .= self::get_spacing_styles();
-        $dynamic_styles .= self::get_border_styles();
-        $dynamic_styles .= self::get_input_size_styles();
+        $dynamic_styles .= self::get_color_styles($overrides);
+        $dynamic_styles .= self::get_border_radius_styles($overrides);
+        $dynamic_styles .= self::get_font_styles($overrides);
+        $dynamic_styles .= self::get_spacing_styles($overrides);
+        $dynamic_styles .= self::get_border_styles($overrides);
+        $dynamic_styles .= self::get_input_size_styles($overrides);
 
         $custom_css = '';
         if (!empty($dynamic_styles)) {
             $custom_css .= '.petitioner {' . $dynamic_styles . ' } ';
         }
 
-        $custom_css .= get_option('petitioner_custom_css', '');
+        $custom_css .= self::get_setting('petitioner_custom_css', $overrides);
 
         return $custom_css;
     }
@@ -163,23 +180,24 @@ class AV_Petitioner_Dynamic_CSS
     /**
      * Generates CSS variables for color settings.
      *
+     * @param array $overrides Optional overrides.
      * @return string The color CSS styles.
      */
-    private static function get_color_styles()
+    private static function get_color_styles($overrides = [])
     {
         $styles = '';
 
-        $primary = sanitize_hex_color(get_option('petitioner_primary_color', ''));
+        $primary = sanitize_hex_color(self::get_setting('petitioner_primary_color', $overrides));
         if (!empty($primary)) {
             $styles .= '--ptr-color-primary: ' . $primary . '!important;';
         }
 
-        $dark = sanitize_hex_color(get_option('petitioner_dark_color', ''));
+        $dark = sanitize_hex_color(self::get_setting('petitioner_dark_color', $overrides));
         if (!empty($dark)) {
             $styles .= '--ptr-color-dark: ' . $dark . '!important;';
         }
 
-        $grey = sanitize_hex_color(get_option('petitioner_grey_color', ''));
+        $grey = sanitize_hex_color(self::get_setting('petitioner_grey_color', $overrides));
         if (!empty($grey)) {
             $styles .= '--ptr-color-grey: ' . $grey . '!important;';
         }
@@ -190,12 +208,13 @@ class AV_Petitioner_Dynamic_CSS
     /**
      * Generates CSS variables for border radius settings.
      *
+     * @param array $overrides Optional overrides.
      * @return string The border radius CSS styles.
      */
-    private static function get_border_radius_styles()
+    private static function get_border_radius_styles($overrides = [])
     {
         $styles = '';
-        $radius = get_option('petitioner_border_radius', '');
+        $radius = self::get_setting('petitioner_border_radius', $overrides);
 
         if (self::is_valid_option($radius, 'border_radius')) {
             $styles .= '--ptr-input-border-radius: var(--ptr-border-radius-' . $radius . ')!important;';
@@ -212,18 +231,19 @@ class AV_Petitioner_Dynamic_CSS
     /**
      * Generates CSS variables for font size settings.
      *
+     * @param array $overrides Optional overrides.
      * @return string The font size CSS styles.
      */
-    private static function get_font_styles()
+    private static function get_font_styles($overrides = [])
     {
         $styles = '';
 
-        $base = get_option('petitioner_base_font_size', '');
+        $base = self::get_setting('petitioner_base_font_size', $overrides);
         if (self::is_valid_option($base, 'base_font_size')) {
             $styles .= '--ptr-label-font-size: var(--ptr-fs-' . $base . ')!important;';
         }
 
-        $btn = get_option('petitioner_button_font_size', '');
+        $btn = self::get_setting('petitioner_button_font_size', $overrides);
         if (self::is_valid_option($btn, 'button_font_size')) {
             $styles .= '--ptr-btn-font-size: var(--ptr-fs-' . $btn . ')!important;';
         }
@@ -234,12 +254,13 @@ class AV_Petitioner_Dynamic_CSS
     /**
      * Generates CSS variables for field spacing settings.
      *
+     * @param array $overrides Optional overrides.
      * @return string The field spacing CSS styles.
      */
-    private static function get_spacing_styles()
+    private static function get_spacing_styles($overrides = [])
     {
         $styles = '';
-        $spacing = get_option('petitioner_field_spacing', '');
+        $spacing = self::get_setting('petitioner_field_spacing', $overrides);
 
         if (self::is_valid_option($spacing, 'field_spacing')) {
             $styles .= '--ptr-input-margin-bottom: var(--ptr-spacer-' . $spacing . ')!important;';
@@ -251,12 +272,13 @@ class AV_Petitioner_Dynamic_CSS
     /**
      * Generates CSS variables for input border width settings.
      *
+     * @param array $overrides Optional overrides.
      * @return string The input border width CSS styles.
      */
-    private static function get_border_styles()
+    private static function get_border_styles($overrides = [])
     {
         $styles = '';
-        $width = get_option('petitioner_input_border_width', '');
+        $width = self::get_setting('petitioner_input_border_width', $overrides);
 
         if (self::is_valid_option($width, 'input_border_width')) {
             $styles .= '--ptr-input-border-width: ' . $width . '!important;';
@@ -268,12 +290,13 @@ class AV_Petitioner_Dynamic_CSS
     /**
      * Generates CSS variables for input size settings.
      *
+     * @param array $overrides Optional overrides.
      * @return string The input size CSS styles.
      */
-    private static function get_input_size_styles()
+    private static function get_input_size_styles($overrides = [])
     {
         $styles = '';
-        $size = get_option('petitioner_input_size', '');
+        $size = self::get_setting('petitioner_input_size', $overrides);
 
         if (empty($size) || !self::is_valid_option($size, 'input_size')) {
             return $styles;

--- a/inc/frontend/class-dynamic-css.php
+++ b/inc/frontend/class-dynamic-css.php
@@ -1,0 +1,147 @@
+<?php
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+/**
+ * Class AV_Petitioner_Dynamic_CSS
+ *
+ * Handles the extraction, validation, and generation of dynamic CSS
+ * based on the user's visual settings.
+ *
+ * @since 0.8.5
+ */
+class AV_Petitioner_Dynamic_CSS
+{
+    const ALLOWED_SIZES = ['xs', 'sm', 'md', 'lg', 'xl', 'full'];
+    const ALLOWED_BORDER_WIDTHS = ['0px', '1px', '2px', '3px'];
+
+    public static function generate_css()
+    {
+        $dynamic_styles = '';
+        $dynamic_styles .= self::get_color_styles();
+        $dynamic_styles .= self::get_border_radius_styles();
+        $dynamic_styles .= self::get_font_styles();
+        $dynamic_styles .= self::get_spacing_styles();
+        $dynamic_styles .= self::get_border_styles();
+        $dynamic_styles .= self::get_input_size_styles();
+
+        $custom_css = '';
+        if (!empty($dynamic_styles)) {
+            $custom_css .= '.petitioner {' . $dynamic_styles . ' } ';
+        }
+
+        $custom_css .= get_option('petitioner_custom_css', '');
+
+        return $custom_css;
+    }
+
+    private static function get_color_styles()
+    {
+        $styles = '';
+        
+        $primary = sanitize_hex_color(get_option('petitioner_primary_color', ''));
+        if (!empty($primary)) {
+            $styles .= '--ptr-color-primary: ' . $primary . '!important;';
+        }
+
+        $dark = sanitize_hex_color(get_option('petitioner_dark_color', ''));
+        if (!empty($dark)) {
+            $styles .= '--ptr-color-dark: ' . $dark . '!important;';
+        }
+
+        $grey = sanitize_hex_color(get_option('petitioner_grey_color', ''));
+        if (!empty($grey)) {
+            $styles .= '--ptr-color-grey: ' . $grey . '!important;';
+        }
+
+        return $styles;
+    }
+
+    private static function get_border_radius_styles()
+    {
+        $styles = '';
+        $radius = get_option('petitioner_border_radius', '');
+
+        if (!empty($radius) && in_array($radius, self::ALLOWED_SIZES, true)) {
+            $styles .= '--ptr-input-border-radius: var(--ptr-border-radius-' . $radius . ')!important;';
+            $styles .= '--ptr-button-border-radius: var(--ptr-border-radius-' . $radius . ')!important;';
+            
+            // Limit wrapper radius to 'lg' so it doesn't become a pill
+            $wrapper = $radius === 'full' ? 'lg' : $radius;
+            $styles .= '--ptr-wrapper-radius: var(--ptr-border-radius-' . $wrapper . ')!important;';
+        }
+
+        return $styles;
+    }
+
+    private static function get_font_styles()
+    {
+        $styles = '';
+        
+        $base = get_option('petitioner_base_font_size', '');
+        if (!empty($base) && in_array($base, self::ALLOWED_SIZES, true)) {
+            $styles .= '--ptr-label-font-size: var(--ptr-fs-' . $base . ')!important;';
+        }
+
+        $btn = get_option('petitioner_button_font_size', '');
+        if (!empty($btn) && in_array($btn, self::ALLOWED_SIZES, true)) {
+            $styles .= '--ptr-btn-font-size: var(--ptr-fs-' . $btn . ')!important;';
+        }
+
+        return $styles;
+    }
+
+    private static function get_spacing_styles()
+    {
+        $styles = '';
+        $spacing = get_option('petitioner_field_spacing', '');
+
+        if (!empty($spacing) && in_array($spacing, self::ALLOWED_SIZES, true)) {
+            $styles .= '--ptr-input-margin-bottom: var(--ptr-spacer-' . $spacing . ')!important;';
+        }
+
+        return $styles;
+    }
+
+    private static function get_border_styles()
+    {
+        $styles = '';
+        $width = get_option('petitioner_input_border_width', '');
+
+        if (!empty($width) && in_array($width, self::ALLOWED_BORDER_WIDTHS, true)) {
+            $styles .= '--ptr-input-border-width: ' . $width . '!important;';
+        }
+
+        return $styles;
+    }
+
+    private static function get_input_size_styles()
+    {
+        $styles = '';
+        $size = get_option('petitioner_input_size', '');
+
+        switch ($size) {
+            case 'sm':
+                $styles .= '--ptr-input-line-height: 24px !important;';
+                $styles .= '--ptr-input-spacing-y: 4px !important;';
+                $styles .= '--ptr-label-line-height: 1.4 !important;';
+                break;
+            case 'md':
+                $styles .= '--ptr-input-line-height: 24px !important;';
+                $styles .= '--ptr-input-spacing-y: 8px !important;';
+                break;
+            case 'lg':
+                $styles .= '--ptr-input-line-height: 32px !important;';
+                $styles .= '--ptr-input-spacing-y: 8px !important;';
+                break;
+            case 'xl':
+                $styles .= '--ptr-input-line-height: 40px !important;';
+                $styles .= '--ptr-input-spacing-y: 0.7rem !important;';
+                break;
+        }
+
+        return $styles;
+    }
+}

--- a/inc/frontend/class-dynamic-css.php
+++ b/inc/frontend/class-dynamic-css.php
@@ -32,9 +32,14 @@ class AV_Petitioner_Dynamic_CSS
      */
     public static function inject_schema_options($settings)
     {
-        if (!isset($settings['default_values'])) {
+        if (!is_array($settings)) {
+            $settings = [];
+        }
+
+        if (!isset($settings['default_values']) || !is_array($settings['default_values'])) {
             $settings['default_values'] = [];
         }
+
         $settings['default_values']['visual_options'] = self::get_schema_options();
         return $settings;
     }
@@ -109,6 +114,28 @@ class AV_Petitioner_Dynamic_CSS
     }
 
     /**
+     * Safely validates a visual option against the schema.
+     *
+     * @param string $value      The value to validate.
+     * @param string $schema_key The schema category key (e.g. 'border_radius').
+     * @return bool True if valid, false otherwise.
+     */
+    private static function is_valid_option($value, $schema_key)
+    {
+        if (empty($value)) {
+            return false;
+        }
+
+        $schema = self::get_schema_options();
+
+        if (!isset($schema[$schema_key]) || !is_array($schema[$schema_key])) {
+            return false;
+        }
+
+        return array_key_exists($value, $schema[$schema_key]);
+    }
+
+    /**
      * Generates all dynamic CSS styles based on saved options.
      *
      * @return string The generated CSS string.
@@ -170,8 +197,7 @@ class AV_Petitioner_Dynamic_CSS
         $styles = '';
         $radius = get_option('petitioner_border_radius', '');
 
-        $schema = self::get_schema_options();
-        if (!empty($radius) && array_key_exists($radius, $schema['border_radius'])) {
+        if (self::is_valid_option($radius, 'border_radius')) {
             $styles .= '--ptr-input-border-radius: var(--ptr-border-radius-' . $radius . ')!important;';
             $styles .= '--ptr-button-border-radius: var(--ptr-border-radius-' . $radius . ')!important;';
 
@@ -193,13 +219,12 @@ class AV_Petitioner_Dynamic_CSS
         $styles = '';
 
         $base = get_option('petitioner_base_font_size', '');
-        $schema = self::get_schema_options();
-        if (!empty($base) && array_key_exists($base, $schema['base_font_size'])) {
+        if (self::is_valid_option($base, 'base_font_size')) {
             $styles .= '--ptr-label-font-size: var(--ptr-fs-' . $base . ')!important;';
         }
 
         $btn = get_option('petitioner_button_font_size', '');
-        if (!empty($btn) && array_key_exists($btn, $schema['button_font_size'])) {
+        if (self::is_valid_option($btn, 'button_font_size')) {
             $styles .= '--ptr-btn-font-size: var(--ptr-fs-' . $btn . ')!important;';
         }
 
@@ -216,8 +241,7 @@ class AV_Petitioner_Dynamic_CSS
         $styles = '';
         $spacing = get_option('petitioner_field_spacing', '');
 
-        $schema = self::get_schema_options();
-        if (!empty($spacing) && array_key_exists($spacing, $schema['field_spacing'])) {
+        if (self::is_valid_option($spacing, 'field_spacing')) {
             $styles .= '--ptr-input-margin-bottom: var(--ptr-spacer-' . $spacing . ')!important;';
         }
 
@@ -234,8 +258,7 @@ class AV_Petitioner_Dynamic_CSS
         $styles = '';
         $width = get_option('petitioner_input_border_width', '');
 
-        $schema = self::get_schema_options();
-        if (!empty($width) && array_key_exists($width, $schema['input_border_width'])) {
+        if (self::is_valid_option($width, 'input_border_width')) {
             $styles .= '--ptr-input-border-width: ' . $width . '!important;';
         }
 
@@ -252,8 +275,7 @@ class AV_Petitioner_Dynamic_CSS
         $styles = '';
         $size = get_option('petitioner_input_size', '');
 
-        $schema = self::get_schema_options();
-        if (!empty($size) && !array_key_exists($size, $schema['input_size'])) {
+        if (empty($size) || !self::is_valid_option($size, 'input_size')) {
             return $styles;
         }
 

--- a/inc/frontend/class-dynamic-css.php
+++ b/inc/frontend/class-dynamic-css.php
@@ -174,6 +174,9 @@ class AV_Petitioner_Dynamic_CSS
 
         $custom_css .= self::get_setting('petitioner_custom_css', $overrides);
 
+        // Sanitize the final CSS to prevent XSS/HTML injection while preserving valid CSS chars like <
+        $custom_css = preg_replace('#<\s*/?\s*style\b[^>]*>?#is', '', $custom_css);
+
         return $custom_css;
     }
 

--- a/inc/frontend/class-dynamic-css.php
+++ b/inc/frontend/class-dynamic-css.php
@@ -122,7 +122,7 @@ class AV_Petitioner_Dynamic_CSS
      */
     private static function is_valid_option($value, $schema_key)
     {
-        if (empty($value)) {
+        if (!is_string($value) || $value === '') {
             return false;
         }
 

--- a/inc/submissions/class-submissions-controller.php
+++ b/inc/submissions/class-submissions-controller.php
@@ -834,6 +834,9 @@ class AV_Petitioner_Submissions_Controller
         $submission = AV_Petitioner_Submissions_Model::get_submission_by_id($submission_id);
 
         if ($submission) {
+            // ensure we pass custom properties correctly here
+            $submission = AV_Petitioner_Custom_Properties::hydrate_submission($submission);
+
             /**
              * petitioner_submission_finalized
              *

--- a/inc/submissions/class-submissions-controller.php
+++ b/inc/submissions/class-submissions-controller.php
@@ -315,7 +315,7 @@ class AV_Petitioner_Submissions_Controller
             $fetch_settings['order'] = $order;
         }
 
-        if ($orderby && in_array($orderby, $fields, true)) {
+        if ($orderby && in_array($orderby, $public_fields, true)) {
             $fetch_settings['orderby'] = $orderby;
         }
 

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
 		"@wordpress/data": "^10.49.0",
 		"@wordpress/element": "^8.1.0",
 		"@wordpress/hooks": "^4.49.0",
+		"@wordpress/html-entities": "^4.50.0",
 		"@wordpress/i18n": "^6.22.0",
 		"@wordpress/prettier-config": "^4.49.0",
 		"@wordpress/scripts": "^32.5.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "petitioner",
-	"version": "0.8.4",
+	"version": "0.8.5",
 	"description": "A WordPress plugin for collecting petitions",
 	"main": "index.js",
 	"scripts": {

--- a/petitioner.php
+++ b/petitioner.php
@@ -72,6 +72,8 @@ require_once AV_PETITIONER_PLUGIN_DIR . 'inc/labels/class-label-overrides.php';
 
 $petitioner_setup = new AV_Petitioner_Setup();
 
+AV_Petitioner_Dynamic_CSS::init();
+
 new AV_Email_Confirmations();
 
 register_activation_hook(__FILE__, array('AV_Petitioner_Setup', 'plugin_activation'));

--- a/petitioner.php
+++ b/petitioner.php
@@ -5,7 +5,7 @@
  * Description:       A WordPress plugin for collecting petitions.
  * Requires at least: 5.9
  * Requires PHP:      8.0
- * Version:           0.8.4
+ * Version:           0.8.5
  * Author:            Anton Voytenko
  * License:           GPLv2 or later
  * License URI:       http://www.gnu.org/licenses/gpl-2.0.html
@@ -19,7 +19,7 @@ if (!defined('ABSPATH')) {
 
 define('AV_PETITIONER_PLUGIN_DIR', plugin_dir_path(__FILE__));
 
-define('AV_PETITIONER_PLUGIN_VERSION', '0.8.4');
+define('AV_PETITIONER_PLUGIN_VERSION', '0.8.5');
 
 if (!function_exists('av_ptr_error_log')) {
 

--- a/petitioner.php
+++ b/petitioner.php
@@ -62,6 +62,7 @@ require_once AV_PETITIONER_PLUGIN_DIR . 'inc/frontend/class-dynamic-css.php';
 require_once AV_PETITIONER_PLUGIN_DIR . 'inc/frontend/class-shortcodes.php';
 require_once AV_PETITIONER_PLUGIN_DIR . 'inc/admin-ui/edit-form/class-admin-edit-ui.php';
 require_once AV_PETITIONER_PLUGIN_DIR . 'inc/admin-ui/settings/class-admin-settings-ui.php';
+require_once AV_PETITIONER_PLUGIN_DIR . 'inc/admin-ui/settings/class-admin-live-preview.php';
 require_once AV_PETITIONER_PLUGIN_DIR . 'inc/admin-ui/class-admin-component-preview-ui.php';
 require_once AV_PETITIONER_PLUGIN_DIR . 'inc/admin-ui/class-admin-shared.php';
 require_once AV_PETITIONER_PLUGIN_DIR . 'inc/gutenberg/class-gutenberg.php';
@@ -72,6 +73,8 @@ require_once AV_PETITIONER_PLUGIN_DIR . 'inc/labels/class-label-overrides.php';
 
 $petitioner_setup = new AV_Petitioner_Setup();
 
+AV_Petitioner_Dynamic_CSS::init();
+AV_Petitioner_Admin_Live_Preview::init();
 new AV_Email_Confirmations();
 
 register_activation_hook(__FILE__, array('AV_Petitioner_Setup', 'plugin_activation'));

--- a/petitioner.php
+++ b/petitioner.php
@@ -73,8 +73,6 @@ require_once AV_PETITIONER_PLUGIN_DIR . 'inc/labels/class-label-overrides.php';
 
 $petitioner_setup = new AV_Petitioner_Setup();
 
-AV_Petitioner_Dynamic_CSS::init();
-AV_Petitioner_Admin_Live_Preview::init();
 new AV_Email_Confirmations();
 
 register_activation_hook(__FILE__, array('AV_Petitioner_Setup', 'plugin_activation'));

--- a/petitioner.php
+++ b/petitioner.php
@@ -58,6 +58,7 @@ require_once AV_PETITIONER_PLUGIN_DIR . 'inc/emails/class-email-template.php';
 require_once AV_PETITIONER_PLUGIN_DIR . 'inc/emails/class-mailer.php';
 require_once AV_PETITIONER_PLUGIN_DIR . 'inc/frontend/class-frontend-ui.php';
 require_once AV_PETITIONER_PLUGIN_DIR . 'inc/frontend/class-form-ui.php';
+require_once AV_PETITIONER_PLUGIN_DIR . 'inc/frontend/class-dynamic-css.php';
 require_once AV_PETITIONER_PLUGIN_DIR . 'inc/frontend/class-shortcodes.php';
 require_once AV_PETITIONER_PLUGIN_DIR . 'inc/admin-ui/edit-form/class-admin-edit-ui.php';
 require_once AV_PETITIONER_PLUGIN_DIR . 'inc/admin-ui/settings/class-admin-settings-ui.php';

--- a/petitioner.php
+++ b/petitioner.php
@@ -72,8 +72,6 @@ require_once AV_PETITIONER_PLUGIN_DIR . 'inc/labels/class-label-overrides.php';
 
 $petitioner_setup = new AV_Petitioner_Setup();
 
-AV_Petitioner_Dynamic_CSS::init();
-
 new AV_Email_Confirmations();
 
 register_activation_hook(__FILE__, array('AV_Petitioner_Setup', 'plugin_activation'));

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -76,6 +76,9 @@ importers:
       '@wordpress/hooks':
         specifier: ^4.49.0
         version: 4.49.0
+      '@wordpress/html-entities':
+        specifier: ^4.50.0
+        version: 4.50.0
       '@wordpress/i18n':
         specifier: ^6.22.0
         version: 6.22.0
@@ -2863,8 +2866,8 @@ packages:
     resolution: {integrity: sha512-65FZ3UXWkSIwFbELFABmcWn1KTA1AUdGAUH8pQlO7HKNO8F+zIrDkkO8gZA/zUHbI3I2vI1PyTA+rherPXg+Kg==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
 
-  '@wordpress/html-entities@4.49.0':
-    resolution: {integrity: sha512-/ZYK6CPks3VAGFQZ+h56jOy4LB4CC1ZB1SMVY3eeUPStyH84YSz7nTa2P7gw/4uGJhaITMQCmFl7yGFPQOROtg==}
+  '@wordpress/html-entities@4.50.0':
+    resolution: {integrity: sha512-RWoT58IXeX82fC7zBLiTNEDdKN/fTAHWlMJbEwMH65UTzJt5jNWtmVdbtTZP248ceyAK3lUsWaXei2t1bqAyNA==}
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
 
   '@wordpress/i18n@6.22.0':
@@ -11369,7 +11372,7 @@ snapshots:
       '@wordpress/escape-html': 3.49.0
       '@wordpress/global-styles-engine': 1.16.0(@types/react@18.3.31)(react@18.3.1)
       '@wordpress/hooks': 4.49.0
-      '@wordpress/html-entities': 4.49.0
+      '@wordpress/html-entities': 4.50.0
       '@wordpress/i18n': 6.22.0
       '@wordpress/icons': 15.0.0(@types/react@18.3.31)(react@18.3.1)
       '@wordpress/image-cropper': 1.13.0(@date-fns/tz@1.5.0)(@emotion/is-prop-valid@1.4.0)(@types/react@18.3.31)(postcss@8.5.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(stylelint@16.26.1(typescript@5.9.3))(vite@8.1.0(@types/node@22.20.0)(sass@1.101.0)(terser@5.48.0))
@@ -11429,7 +11432,7 @@ snapshots:
       '@wordpress/dom': 4.49.0
       '@wordpress/element': 8.1.0
       '@wordpress/hooks': 4.49.0
-      '@wordpress/html-entities': 4.49.0
+      '@wordpress/html-entities': 4.50.0
       '@wordpress/i18n': 6.22.0
       '@wordpress/is-shallow-equal': 5.49.0
       '@wordpress/private-apis': 1.49.0
@@ -11503,7 +11506,7 @@ snapshots:
       '@wordpress/element': 8.1.0
       '@wordpress/escape-html': 3.49.0
       '@wordpress/hooks': 4.49.0
-      '@wordpress/html-entities': 4.49.0
+      '@wordpress/html-entities': 4.50.0
       '@wordpress/i18n': 6.22.0
       '@wordpress/icons': 15.0.0(@types/react@18.3.31)(react@18.3.1)
       '@wordpress/is-shallow-equal': 5.49.0
@@ -11683,7 +11686,7 @@ snapshots:
       eslint: 10.6.0
       eslint-config-prettier: 10.1.8(eslint@10.6.0)
       eslint-import-resolver-typescript: 4.4.5(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.62.0(eslint@10.6.0)(typescript@5.9.3))(eslint@10.6.0))(eslint@10.6.0)
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.62.0(eslint@10.6.0)(typescript@5.9.3))(eslint-import-resolver-typescript@4.4.5(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.62.0(eslint@10.6.0)(typescript@5.9.3))(eslint@10.6.0))(eslint@10.6.0))(eslint@10.6.0)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.62.0(eslint@10.6.0)(typescript@5.9.3))(eslint-import-resolver-typescript@4.4.5)(eslint@10.6.0)
       eslint-plugin-jest: 28.14.0(@typescript-eslint/eslint-plugin@8.62.0(@typescript-eslint/parser@8.62.0(eslint@10.6.0)(typescript@5.9.3))(eslint@10.6.0)(typescript@5.9.3))(eslint@10.6.0)(jest@29.7.0(@types/node@22.20.0)(babel-plugin-macros@3.1.0))(typescript@5.9.3)
       eslint-plugin-jsdoc: 50.8.0(eslint@10.6.0)
       eslint-plugin-jsx-a11y: 6.10.2(eslint@10.6.0)
@@ -11730,7 +11733,7 @@ snapshots:
 
   '@wordpress/hooks@4.49.0': {}
 
-  '@wordpress/html-entities@4.49.0': {}
+  '@wordpress/html-entities@4.50.0': {}
 
   '@wordpress/i18n@6.22.0':
     dependencies:
@@ -13466,7 +13469,7 @@ snapshots:
       tinyglobby: 0.2.17
       unrs-resolver: 1.12.2
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.62.0(eslint@10.6.0)(typescript@5.9.3))(eslint-import-resolver-typescript@4.4.5(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.62.0(eslint@10.6.0)(typescript@5.9.3))(eslint@10.6.0))(eslint@10.6.0))(eslint@10.6.0)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.62.0(eslint@10.6.0)(typescript@5.9.3))(eslint-import-resolver-typescript@4.4.5)(eslint@10.6.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -13481,7 +13484,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.62.0(eslint@10.6.0)(typescript@5.9.3))(eslint-import-resolver-typescript@4.4.5(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.62.0(eslint@10.6.0)(typescript@5.9.3))(eslint@10.6.0))(eslint@10.6.0))(eslint@10.6.0):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.62.0(eslint@10.6.0)(typescript@5.9.3))(eslint-import-resolver-typescript@4.4.5)(eslint@10.6.0):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9

--- a/readme.txt
+++ b/readme.txt
@@ -148,6 +148,11 @@ You can find a more extensive FAQ [on the main website](https://getpetitioner.co
 
 == Changelog ==
 
+= 0.8.5 =
+* Improvements
+    * Additional controls in the styles customizer and a preview
+    * Improved the `petitioner_submission_finalized` hook: it now hydrates the submission data that it sends. Good for working with the custom fields.
+
 = 0.8.4 =
 * Improvements
     * Submissions Gutenberg block now has a proper preview in the admin UI (instead of a grey placeholder box)

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link: https://avoy.me/
 Tags: petition, activism, form, community, email
 Requires at least: 6.3
 Tested up to: 7.0
-Stable Tag: 0.8.4
+Stable Tag: 0.8.5
 Requires PHP: 8.0
 License: GPLv2 or later 
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/readme.txt
+++ b/readme.txt
@@ -150,7 +150,8 @@ You can find a more extensive FAQ [on the main website](https://getpetitioner.co
 
 = 0.8.5 =
 * Improvements
-    * Additional controls in the styles customizer and a preview
+    * Additional spacing and font size controls in the styles customizer
+    * A new visual preview in the customizer
     * Improved the `petitioner_submission_finalized` hook: it now hydrates the submission data that it sends. Good for working with the custom fields.
 
 = 0.8.4 =

--- a/src/css/frontend/partials/base.css
+++ b/src/css/frontend/partials/base.css
@@ -23,14 +23,17 @@
     --ptr-color-grey: #efefef;
 
     /* Font sizes */
+    --ptr-fs-xs: 12px;
     --ptr-fs-sm: 14px;
-    --ptr-fs-md: 18px;
+    --ptr-fs-md: 16px;
+    --ptr-fs-lg: 18px;
 
     /* Border radius */
     --ptr-border-radius-xs: 2px;
     --ptr-border-radius-sm: 4px;
     --ptr-border-radius-md: 8px;
     --ptr-border-radius-lg: 16px;
+    --ptr-border-radius-full: 999px;
 
 }
 
@@ -48,13 +51,15 @@
     --ptr-input-border-radius: var(--ptr-border-radius-md);
     --ptr-input-spacing-y: 0.7rem;
     --ptr-input-spacing-x: var(--ptr-spacer-md);
+    --ptr-input-margin-bottom: var(--ptr-spacer-sm);
     --ptr-input-line-height: 40px;
 
     /* label related */
     --ptr-label-font-size: var(--ptr-fs-sm);
+    --ptr-label-line-height: 1.5;
 
     /* button */
-    --ptr-btn-font-size: var(--ptr-fs-md);
+    --ptr-btn-font-size: var(--ptr-fs-lg);
     --ptr-btn-bg: var(--ptr-color-primary);
     --ptr-btn-bg-hover: var(--ptr-color-dark);
     --ptr-button-border-width: var(--ptr-input-border-width);
@@ -81,11 +86,12 @@
     display: flex;
     flex-direction: column;
     gap: var(--ptr-spacer-xs);
-    margin-bottom: var(--ptr-spacer-sm);
+    margin-bottom: var(--ptr-input-margin-bottom);
 }
 
 .petitioner__input label {
     font-size: var(--ptr-label-font-size);
+    line-height: var(--ptr-label-line-height);
 }
 
 .petitioner__input input:not([type="checkbox"]),
@@ -203,7 +209,7 @@
 }
 
 .petitioner__btn--submit {
-    font-size: var(--ptr-fs-md);
+    font-size: var(--ptr-btn-font-size);
     background-color: var(--ptr-color-primary);
     color: white;
 }

--- a/src/js/admin/components/CodeEditor.tsx
+++ b/src/js/admin/components/CodeEditor.tsx
@@ -5,37 +5,46 @@ interface CodeEditorProps {
 	help?: string;
 	code?: string;
 	onChange?: (code: string) => void;
+	/** We want to reinitialize it if the active tab is different on load so it calculates the styles correctly */
+	isActive?: boolean;
 }
 
-export default function CodeEditor({ title = '', help = '', code = '', onChange }: CodeEditorProps) {
+export default function CodeEditor({ title = '', help = '', code = '', onChange, isActive = true }: CodeEditorProps) {
 	const textareaRef = useRef<HTMLTextAreaElement>(null);
-	const initializedRef = useRef(false);
 	const onChangeRef = useRef(onChange);
+	const editorRef = useRef<any>(null);
 
 	useEffect(() => {
 		onChangeRef.current = onChange;
 	}, [onChange]);
 
 	useEffect(() => {
-		if (window.wp?.codeEditor && textareaRef.current && !initializedRef.current) {
-			initializedRef.current = true;
-
+		if (window.wp?.codeEditor && textareaRef.current && !editorRef.current) {
 			const editorConfig = { type: 'text/css' };
-			const editorInstance = window.wp.codeEditor.initialize(textareaRef.current, editorConfig);
+			editorRef.current = window.wp.codeEditor.initialize(textareaRef.current, editorConfig);
 
-			if (editorInstance?.codemirror) {
+			if (editorRef.current?.codemirror) {
 				let timeout: NodeJS.Timeout;
-				editorInstance.codemirror.on('change', () => {
+				editorRef.current.codemirror.on('change', () => {
 					clearTimeout(timeout);
 					timeout = setTimeout(() => {
 						if (onChangeRef.current) {
-							onChangeRef.current(editorInstance.codemirror.getValue());
+							onChangeRef.current(editorRef.current.codemirror.getValue());
 						}
 					}, 500);
 				});
 			}
 		}
 	}, []);
+
+	useEffect(() => {
+		if (isActive && editorRef.current?.codemirror) {
+			// A small delay ensures the container has finished rendering as visible
+			setTimeout(() => {
+				editorRef.current.codemirror.refresh();
+			}, 0);
+		}
+	}, [isActive]);
 
 	return (
 		<div>

--- a/src/js/admin/components/CodeEditor.tsx
+++ b/src/js/admin/components/CodeEditor.tsx
@@ -40,6 +40,13 @@ export default function CodeEditor({ title = '', help = '', code = '', onChange,
 				editorRef.current.codemirror.refresh();
 			}, 0);
 		}
+
+		return () => {
+			if (editorRef.current?.codemirror) {
+				editorRef.current.codemirror.toTextArea();
+				editorRef.current = null;
+			}
+		};
 	}, [isActive]);
 
 	return (

--- a/src/js/admin/components/CodeEditor.tsx
+++ b/src/js/admin/components/CodeEditor.tsx
@@ -19,15 +19,17 @@ export default function CodeEditor({ title = '', help = '', code = '', onChange,
 	}, [onChange]);
 
 	useEffect(() => {
+		let debounceTimeout: ReturnType<typeof setTimeout>;
+		let refreshTimeout: ReturnType<typeof setTimeout>;
+
 		if (isActive && window.wp?.codeEditor && textareaRef.current && !editorRef.current) {
 			const editorConfig = { type: 'text/css' };
 			editorRef.current = window.wp.codeEditor.initialize(textareaRef.current, editorConfig);
 
 			if (editorRef.current?.codemirror) {
-				let timeout: ReturnType<typeof setTimeout>;
 				editorRef.current.codemirror.on('change', () => {
-					clearTimeout(timeout);
-					timeout = setTimeout(() => {
+					clearTimeout(debounceTimeout);
+					debounceTimeout = setTimeout(() => {
 						if (onChangeRef.current) {
 							onChangeRef.current(editorRef.current.codemirror.getValue());
 						}
@@ -36,12 +38,14 @@ export default function CodeEditor({ title = '', help = '', code = '', onChange,
 			}
 		} else if (isActive && editorRef.current?.codemirror) {
 			// A small delay ensures the container has finished rendering as visible
-			setTimeout(() => {
+			refreshTimeout = setTimeout(() => {
 				editorRef.current.codemirror.refresh();
 			}, 0);
 		}
 
 		return () => {
+			clearTimeout(debounceTimeout);
+			clearTimeout(refreshTimeout);
 			if (editorRef.current?.codemirror) {
 				editorRef.current.codemirror.toTextArea();
 				editorRef.current = null;

--- a/src/js/admin/components/CodeEditor.tsx
+++ b/src/js/admin/components/CodeEditor.tsx
@@ -19,7 +19,7 @@ export default function CodeEditor({ title = '', help = '', code = '', onChange,
 	}, [onChange]);
 
 	useEffect(() => {
-		if (window.wp?.codeEditor && textareaRef.current && !editorRef.current) {
+		if (isActive && window.wp?.codeEditor && textareaRef.current && !editorRef.current) {
 			const editorConfig = { type: 'text/css' };
 			editorRef.current = window.wp.codeEditor.initialize(textareaRef.current, editorConfig);
 
@@ -34,11 +34,7 @@ export default function CodeEditor({ title = '', help = '', code = '', onChange,
 					}, 500);
 				});
 			}
-		}
-	}, []);
-
-	useEffect(() => {
-		if (isActive && editorRef.current?.codemirror) {
+		} else if (isActive && editorRef.current?.codemirror) {
 			// A small delay ensures the container has finished rendering as visible
 			setTimeout(() => {
 				editorRef.current.codemirror.refresh();

--- a/src/js/admin/components/CodeEditor.tsx
+++ b/src/js/admin/components/CodeEditor.tsx
@@ -24,7 +24,7 @@ export default function CodeEditor({ title = '', help = '', code = '', onChange,
 			editorRef.current = window.wp.codeEditor.initialize(textareaRef.current, editorConfig);
 
 			if (editorRef.current?.codemirror) {
-				let timeout: NodeJS.Timeout;
+				let timeout: ReturnType<typeof setTimeout>;;
 				editorRef.current.codemirror.on('change', () => {
 					clearTimeout(timeout);
 					timeout = setTimeout(() => {

--- a/src/js/admin/components/CodeEditor.tsx
+++ b/src/js/admin/components/CodeEditor.tsx
@@ -1,4 +1,35 @@
-export default function CodeEditor({ title = '', help = '', code = '' }) {
+import { useEffect, useRef } from '@wordpress/element';
+
+interface CodeEditorProps {
+	title?: string;
+	help?: string;
+	code?: string;
+	onChange?: (code: string) => void;
+}
+
+export default function CodeEditor({ title = '', help = '', code = '', onChange }: CodeEditorProps) {
+	const textareaRef = useRef<HTMLTextAreaElement>(null);
+	const initializedRef = useRef(false);
+
+	useEffect(() => {
+		if (window.wp?.codeEditor && textareaRef.current && !initializedRef.current) {
+			initializedRef.current = true;
+			
+			const editorConfig = { type: 'text/css' };
+			const editorInstance = window.wp.codeEditor.initialize(textareaRef.current, editorConfig);
+			
+			if (onChange && editorInstance?.codemirror) {
+				let timeout: NodeJS.Timeout;
+				editorInstance.codemirror.on('change', () => {
+					clearTimeout(timeout);
+					timeout = setTimeout(() => {
+						onChange(editorInstance.codemirror.getValue());
+					}, 500);
+				});
+			}
+		}
+	}, [onChange]);
+
 	return (
 		<div>
 			<p>
@@ -6,14 +37,14 @@ export default function CodeEditor({ title = '', help = '', code = '' }) {
 				<span>{help}</span>
 			</p>
 			<textarea
+				ref={textareaRef}
 				name="petitioner_custom_css"
 				id="petitionerCode"
 				rows={10}
 				cols={50}
 				className="large-text code petitioner-code-editor"
-			>
-				{code}
-			</textarea>
+				defaultValue={code}
+			/>
 		</div>
 	);
 }

--- a/src/js/admin/components/CodeEditor.tsx
+++ b/src/js/admin/components/CodeEditor.tsx
@@ -24,7 +24,7 @@ export default function CodeEditor({ title = '', help = '', code = '', onChange,
 			editorRef.current = window.wp.codeEditor.initialize(textareaRef.current, editorConfig);
 
 			if (editorRef.current?.codemirror) {
-				let timeout: ReturnType<typeof setTimeout>;;
+				let timeout: ReturnType<typeof setTimeout>;
 				editorRef.current.codemirror.on('change', () => {
 					clearTimeout(timeout);
 					timeout = setTimeout(() => {

--- a/src/js/admin/components/CodeEditor.tsx
+++ b/src/js/admin/components/CodeEditor.tsx
@@ -10,25 +10,32 @@ interface CodeEditorProps {
 export default function CodeEditor({ title = '', help = '', code = '', onChange }: CodeEditorProps) {
 	const textareaRef = useRef<HTMLTextAreaElement>(null);
 	const initializedRef = useRef(false);
+	const onChangeRef = useRef(onChange);
+
+	useEffect(() => {
+		onChangeRef.current = onChange;
+	}, [onChange]);
 
 	useEffect(() => {
 		if (window.wp?.codeEditor && textareaRef.current && !initializedRef.current) {
 			initializedRef.current = true;
-			
+
 			const editorConfig = { type: 'text/css' };
 			const editorInstance = window.wp.codeEditor.initialize(textareaRef.current, editorConfig);
-			
-			if (onChange && editorInstance?.codemirror) {
+
+			if (editorInstance?.codemirror) {
 				let timeout: NodeJS.Timeout;
 				editorInstance.codemirror.on('change', () => {
 					clearTimeout(timeout);
 					timeout = setTimeout(() => {
-						onChange(editorInstance.codemirror.getValue());
+						if (onChangeRef.current) {
+							onChangeRef.current(editorInstance.codemirror.getValue());
+						}
 					}, 500);
 				});
 			}
 		}
-	}, [onChange]);
+	}, []);
 
 	return (
 		<div>

--- a/src/js/admin/components/Tabs/index.tsx
+++ b/src/js/admin/components/Tabs/index.tsx
@@ -1,5 +1,5 @@
 import { TabPanel } from '@wordpress/components';
-import { useState, useCallback } from '@wordpress/element';
+import { useState, useCallback, isValidElement, cloneElement } from '@wordpress/element';
 import type { TabPanelProps, Tab } from './consts';
 import { updateActiveTabURL } from '@admin/utilities';
 
@@ -44,7 +44,7 @@ export default function Tabs(props: TabPanelProps) {
 							data-testid={`ptr-tab-${el.name}`}
 							className={`petitioner-tab petitioner-tab ${activeTab === el.name ? 'active' : ''}`}
 						>
-							{el.renderingEl}
+							{isValidElement(el.renderingEl) ? cloneElement(el.renderingEl, { isActive: activeTab === el.name } as any) : el.renderingEl}
 						</div>
 					);
 				})}

--- a/src/js/admin/context/SettingsContext.tsx
+++ b/src/js/admin/context/SettingsContext.tsx
@@ -20,6 +20,8 @@ const normalizeSettingsData = (
 ): WindowSettingsData => {
 	const data = {
 		...(raw || {}),
+		home_url: raw?.home_url ?? '/',
+		preview_nonce: raw?.preview_nonce ?? '',
 		show_letter: raw?.show_letter ?? true,
 		show_title: raw?.show_title ?? true,
 		show_goal: raw?.show_goal ?? true,

--- a/src/js/admin/context/SettingsContext.tsx
+++ b/src/js/admin/context/SettingsContext.tsx
@@ -47,6 +47,12 @@ const normalizeSettingsData = (
 			labels: {},
 		},
 		active_tab: raw?.active_tab ?? '',
+		border_radius: raw?.border_radius ?? '',
+		base_font_size: raw?.base_font_size ?? '',
+		button_font_size: raw?.button_font_size ?? '',
+		field_spacing: raw?.field_spacing ?? '',
+		input_border_width: raw?.input_border_width ?? '',
+		input_size: raw?.input_size ?? '',
 	};
 
 	return applyFilters(

--- a/src/js/admin/globals.d.ts
+++ b/src/js/admin/globals.d.ts
@@ -34,6 +34,7 @@ declare global {
 				defaults: Record<string, unknown>;
 				draggable: unknown[];
 			};
+			petitions?: Array<{ id: number; title: string; [key: string]: any }>;
 		};
 		petitionerComponents?: PetitionerComponents;
 	}

--- a/src/js/admin/globals.d.ts
+++ b/src/js/admin/globals.d.ts
@@ -37,6 +37,11 @@ declare global {
 			home_url?: string;
 			petitions?: Array<{ id: number; title: string; [key: string]: any }>;
 		};
+		wp?: {
+			codeEditor?: {
+				initialize: (el: HTMLElement | string, config: any) => any;
+			};
+		};
 		petitionerComponents?: PetitionerComponents;
 	}
 }

--- a/src/js/admin/globals.d.ts
+++ b/src/js/admin/globals.d.ts
@@ -34,6 +34,7 @@ declare global {
 				defaults: Record<string, unknown>;
 				draggable: unknown[];
 			};
+			home_url?: string;
 			petitions?: Array<{ id: number; title: string; [key: string]: any }>;
 		};
 		petitionerComponents?: PetitionerComponents;

--- a/src/js/admin/sections/SettingsFields/FormPreview/consts.ts
+++ b/src/js/admin/sections/SettingsFields/FormPreview/consts.ts
@@ -1,0 +1,1 @@
+export const PREVIEW_UPDATE_EVENT = 'UPDATE_SETTINGS';

--- a/src/js/admin/sections/SettingsFields/FormPreview/consts.ts
+++ b/src/js/admin/sections/SettingsFields/FormPreview/consts.ts
@@ -1,1 +1,3 @@
 export const PREVIEW_UPDATE_EVENT = 'UPDATE_SETTINGS';
+
+export const LOCAL_STORAGE_KEY = 'petitionerFormPreviewID';

--- a/src/js/admin/sections/SettingsFields/FormPreview/hooks.ts
+++ b/src/js/admin/sections/SettingsFields/FormPreview/hooks.ts
@@ -33,9 +33,9 @@ export const useFormPreview = () => {
     const syncPreview = useCallback(async () => {
         if (!iframeRef.current?.contentWindow) return;
 
-        /** We use the provided home_url here instead of the window.location.origin because some setups (like multisites) might have a different frontend URL than admin */
+        /** We use the provided homeUrl here instead of the window.location.origin because some setups (like multisites) might have a different frontend URL than admin */
         const targetOrigin = new URL(
-            windowPetitionerData.home_url || '/',
+            windowPetitionerData.home_url,
             window.location.href
         ).origin;
 
@@ -54,7 +54,7 @@ export const useFormPreview = () => {
         // 2. Fetch compiled CSS via AJAX
         fetchPreviewCSS({
             formState,
-            previewNonce: String(windowPetitionerData.preview_nonce),
+            previewNonce: windowPetitionerData.preview_nonce,
             abortSignal: abortControllerRef.current.signal,
             onSuccess: (css) => {
                 iframeRef.current?.contentWindow?.postMessage(
@@ -86,7 +86,7 @@ export const useFormPreview = () => {
         }
     }, [syncPreview, iframeLoaded]);
 
-    const previewUrl = `${windowPetitionerData.home_url || '/'}?petitioner_live_preview=1&form_id=${selectedFormId}`;
+    const previewUrl = `${windowPetitionerData.home_url}?petitioner_live_preview=1&form_id=${selectedFormId}`;
 
     return {
         iframeRef,

--- a/src/js/admin/sections/SettingsFields/FormPreview/hooks.ts
+++ b/src/js/admin/sections/SettingsFields/FormPreview/hooks.ts
@@ -1,7 +1,7 @@
 import { useRef, useState, useCallback, useEffect } from "@wordpress/element";
 import { useSelect } from "@wordpress/data";
 import { useSettingsFormContext } from "@admin/context/SettingsContext";
-import { fetchPreviewCSS } from "./utilities";
+import { fetchPreviewCSS, localClearSavedFormID, localSaveFormID, localGetSavedFormId } from "./utilities";
 
 export const useFormPreview = () => {
     const iframeRef = useRef<HTMLIFrameElement>(null);
@@ -16,7 +16,14 @@ export const useFormPreview = () => {
         });
     }, []);
 
-    const [selectedFormId, setSelectedFormId] = useState(0);
+    const [selectedFormId, setSelectedFormId] = useState(localGetSavedFormId() ?? 0);
+
+    const onFormSelect = (id: number) => {
+        localClearSavedFormID();
+        setIframeLoaded(false);
+        setSelectedFormId(id);
+        localSaveFormID(id);
+    };
 
     useEffect(() => {
         if (Array.isArray(petitions) && petitions.length > 0 && selectedFormId === 0) {
@@ -85,7 +92,7 @@ export const useFormPreview = () => {
         setIframeLoaded,
         previewUrl,
         selectedFormId,
-        setSelectedFormId,
+        onFormSelect,
         petitions,
         syncPreview,
     }

--- a/src/js/admin/sections/SettingsFields/FormPreview/hooks.ts
+++ b/src/js/admin/sections/SettingsFields/FormPreview/hooks.ts
@@ -1,0 +1,86 @@
+import { useRef, useState, useCallback, useEffect } from "@wordpress/element";
+import { useSelect } from "@wordpress/data";
+import { useSettingsFormContext } from "@admin/context/SettingsContext";
+import { fetchPreviewCSS } from "./utilities";
+
+export const useFormPreview = () => {
+    const iframeRef = useRef<HTMLIFrameElement>(null);
+    const abortControllerRef = useRef<AbortController | null>(null);
+    const { formState } = useSettingsFormContext();
+    const [iframeLoaded, setIframeLoaded] = useState(false);
+
+    const petitions = useSelect((select) => {
+        // @ts-ignore - core-data types might not be fully available
+        return select('core').getEntityRecords('postType', 'petitioner-petition', {
+            per_page: -1,
+        });
+    }, []);
+
+    const [selectedFormId, setSelectedFormId] = useState(0);
+
+    useEffect(() => {
+        if (Array.isArray(petitions) && petitions.length > 0 && selectedFormId === 0) {
+            setSelectedFormId(petitions[0].id);
+        }
+    }, [petitions, selectedFormId]);
+
+    const syncPreview = useCallback(async () => {
+        if (!iframeRef.current?.contentWindow) return;
+
+        const targetOrigin = new URL(
+            window.petitionerData?.home_url || '/',
+            window.location.href
+        ).origin;
+
+        // 1. Send visibility updates instantly
+        iframeRef.current.contentWindow.postMessage(
+            { type: 'UPDATE_VISIBILITY', payload: formState },
+            targetOrigin
+        );
+
+        // Cancel any pending CSS generation requests
+        if (abortControllerRef.current) {
+            abortControllerRef.current.abort();
+        }
+        abortControllerRef.current = new AbortController();
+
+        // 2. Fetch compiled CSS via AJAX
+        fetchPreviewCSS({
+            formState,
+            abortSignal: abortControllerRef.current.signal,
+            onSuccess: (css) => {
+                iframeRef.current?.contentWindow?.postMessage(
+                    { type: 'UPDATE_CSS', payload: css },
+                    targetOrigin
+                );
+            },
+            onError: (msg) => {
+                console.error(msg);
+            },
+        });
+    }, [formState]);
+
+    // Sync settings to the iframe via AJAX + postMessage
+    useEffect(() => {
+        if (!iframeLoaded) return;
+
+        // Debounce the AJAX call
+        const timeout = setTimeout(() => {
+            syncPreview();
+        }, 300);
+
+        return () => clearTimeout(timeout);
+    }, [syncPreview, iframeLoaded]);
+
+    const previewUrl = `${window.petitionerData?.home_url || '/'}?petitioner_live_preview=1&form_id=${selectedFormId}`;
+
+    return {
+        iframeRef,
+        setIframeLoaded,
+        previewUrl,
+        selectedFormId,
+        setSelectedFormId,
+        petitions,
+        syncPreview,
+    }
+}

--- a/src/js/admin/sections/SettingsFields/FormPreview/hooks.ts
+++ b/src/js/admin/sections/SettingsFields/FormPreview/hooks.ts
@@ -69,7 +69,13 @@ export const useFormPreview = () => {
             syncPreview();
         }, 300);
 
-        return () => clearTimeout(timeout);
+        return () => {
+            clearTimeout(timeout);
+            // Abort any in-flight request when unmounting OR when dependencies change
+            if (abortControllerRef.current) {
+                abortControllerRef.current.abort();
+            }
+        }
     }, [syncPreview, iframeLoaded]);
 
     const previewUrl = `${window.petitionerData?.home_url || '/'}?petitioner_live_preview=1&form_id=${selectedFormId}`;

--- a/src/js/admin/sections/SettingsFields/FormPreview/hooks.ts
+++ b/src/js/admin/sections/SettingsFields/FormPreview/hooks.ts
@@ -6,7 +6,7 @@ import { fetchPreviewCSS, localSaveFormID, localGetSavedFormId } from "./utiliti
 export const useFormPreview = () => {
     const iframeRef = useRef<HTMLIFrameElement>(null);
     const abortControllerRef = useRef<AbortController | null>(null);
-    const { formState } = useSettingsFormContext();
+    const { formState, windowPetitionerData } = useSettingsFormContext();
     const [iframeLoaded, setIframeLoaded] = useState(false);
 
     const petitions = useSelect((select) => {
@@ -33,10 +33,7 @@ export const useFormPreview = () => {
     const syncPreview = useCallback(async () => {
         if (!iframeRef.current?.contentWindow) return;
 
-        const targetOrigin = new URL(
-            window.petitionerData?.home_url || '/',
-            window.location.href
-        ).origin;
+        const targetOrigin = window.location.origin;
 
         // 1. Send visibility updates instantly
         iframeRef.current.contentWindow.postMessage(
@@ -84,7 +81,7 @@ export const useFormPreview = () => {
         }
     }, [syncPreview, iframeLoaded]);
 
-    const previewUrl = `${window.petitionerData?.home_url || '/'}?petitioner_live_preview=1&form_id=${selectedFormId}`;
+    const previewUrl = `${windowPetitionerData.home_url || '/'}?petitioner_live_preview=1&form_id=${selectedFormId}`;
 
     return {
         iframeRef,

--- a/src/js/admin/sections/SettingsFields/FormPreview/hooks.ts
+++ b/src/js/admin/sections/SettingsFields/FormPreview/hooks.ts
@@ -50,6 +50,7 @@ export const useFormPreview = () => {
         // 2. Fetch compiled CSS via AJAX
         fetchPreviewCSS({
             formState,
+            previewNonce: String(windowPetitionerData.preview_nonce),
             abortSignal: abortControllerRef.current.signal,
             onSuccess: (css) => {
                 iframeRef.current?.contentWindow?.postMessage(

--- a/src/js/admin/sections/SettingsFields/FormPreview/hooks.ts
+++ b/src/js/admin/sections/SettingsFields/FormPreview/hooks.ts
@@ -33,7 +33,11 @@ export const useFormPreview = () => {
     const syncPreview = useCallback(async () => {
         if (!iframeRef.current?.contentWindow) return;
 
-        const targetOrigin = window.location.origin;
+        /** We use the provided home_url here instead of the window.location.origin because some setups (like multisites) might have a different frontend URL than admin */
+        const targetOrigin = new URL(
+            windowPetitionerData.home_url || '/',
+            window.location.href
+        ).origin;
 
         // 1. Send visibility updates instantly
         iframeRef.current.contentWindow.postMessage(

--- a/src/js/admin/sections/SettingsFields/FormPreview/hooks.ts
+++ b/src/js/admin/sections/SettingsFields/FormPreview/hooks.ts
@@ -1,7 +1,7 @@
 import { useRef, useState, useCallback, useEffect } from "@wordpress/element";
 import { useSelect } from "@wordpress/data";
 import { useSettingsFormContext } from "@admin/context/SettingsContext";
-import { fetchPreviewCSS, localClearSavedFormID, localSaveFormID, localGetSavedFormId } from "./utilities";
+import { fetchPreviewCSS, localSaveFormID, localGetSavedFormId } from "./utilities";
 
 export const useFormPreview = () => {
     const iframeRef = useRef<HTMLIFrameElement>(null);
@@ -19,7 +19,6 @@ export const useFormPreview = () => {
     const [selectedFormId, setSelectedFormId] = useState(localGetSavedFormId() ?? 0);
 
     const onFormSelect = (id: number) => {
-        localClearSavedFormID();
         setIframeLoaded(false);
         setSelectedFormId(id);
         localSaveFormID(id);

--- a/src/js/admin/sections/SettingsFields/FormPreview/index.tsx
+++ b/src/js/admin/sections/SettingsFields/FormPreview/index.tsx
@@ -1,0 +1,55 @@
+import { useEffect, useRef, useState } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import { useSettingsFormContext } from '@admin/context/SettingsContext';
+import { PreviewCard, PreviewHeader, PreviewSelect, PreviewIframe } from './styled';
+import { PREVIEW_UPDATE_EVENT } from './consts';
+
+export default function FormPreview() {
+	const { formState } = useSettingsFormContext();
+	const iframeRef = useRef<HTMLIFrameElement>(null);
+	const petitions = window.petitionerData?.petitions || [];
+	const [selectedFormId, setSelectedFormId] = useState(petitions.length > 0 ? petitions[0].id : 0);
+
+	// Sync settings to the iframe via postMessage
+	useEffect(() => {
+		if (iframeRef.current && iframeRef.current.contentWindow) {
+			iframeRef.current.contentWindow.postMessage(
+				{ type: PREVIEW_UPDATE_EVENT, payload: formState },
+				'*'
+			);
+		}
+	}, [formState]);
+
+	const previewUrl = `${ajaxurl}?action=petitioner_live_preview&form_id=${selectedFormId}`;
+
+	return (
+		<PreviewCard>
+			<PreviewHeader>
+				<span>{__('Live Preview', 'petitioner')}</span>
+				{petitions.length > 0 && (
+					<PreviewSelect 
+						value={selectedFormId} 
+						onChange={(e) => setSelectedFormId(Number(e.target.value))}
+					>
+						{petitions.map((p) => (
+							<option key={p.id} value={p.id}>{p.title}</option>
+						))}
+					</PreviewSelect>
+				)}
+			</PreviewHeader>
+			<PreviewIframe 
+				ref={iframeRef}
+				src={previewUrl} 
+				onLoad={() => {
+					// Trigger initial sync once iframe loads
+					if (iframeRef.current?.contentWindow) {
+						iframeRef.current.contentWindow.postMessage(
+							{ type: PREVIEW_UPDATE_EVENT, payload: formState },
+							'*'
+						);
+					}
+				}}
+			/>
+		</PreviewCard>
+	);
+}

--- a/src/js/admin/sections/SettingsFields/FormPreview/index.tsx
+++ b/src/js/admin/sections/SettingsFields/FormPreview/index.tsx
@@ -8,6 +8,7 @@ import { PreviewCard, PreviewHeader, PreviewSelect, PreviewIframe } from './styl
 export default function FormPreview() {
 	const { formState } = useSettingsFormContext();
 	const iframeRef = useRef<HTMLIFrameElement>(null);
+	const abortControllerRef = useRef<AbortController | null>(null);
 	const [iframeLoaded, setIframeLoaded] = useState(false);
 
 	const petitions = useSelect((select) => {
@@ -39,9 +40,16 @@ export default function FormPreview() {
 			targetOrigin
 		);
 
+		// Cancel any pending CSS generation requests
+		if (abortControllerRef.current) {
+			abortControllerRef.current.abort();
+		}
+		abortControllerRef.current = new AbortController();
+
 		// 2. Fetch compiled CSS via AJAX
 		fetchPreviewCSS({
 			formState,
+			abortSignal: abortControllerRef.current.signal,
 			onSuccess: (css) => {
 				iframeRef.current?.contentWindow?.postMessage(
 					{ type: 'UPDATE_CSS', payload: css },

--- a/src/js/admin/sections/SettingsFields/FormPreview/index.tsx
+++ b/src/js/admin/sections/SettingsFields/FormPreview/index.tsx
@@ -28,10 +28,15 @@ export default function FormPreview() {
 	const syncPreview = useCallback(async () => {
 		if (!iframeRef.current?.contentWindow) return;
 
+		const targetOrigin = new URL(
+			window.petitionerData?.home_url || '/',
+			window.location.href
+		).origin;
+
 		// 1. Send visibility updates instantly
 		iframeRef.current.contentWindow.postMessage(
 			{ type: 'UPDATE_VISIBILITY', payload: formState },
-			'*'
+			targetOrigin
 		);
 
 		// 2. Fetch compiled CSS via AJAX
@@ -40,7 +45,7 @@ export default function FormPreview() {
 			onSuccess: (css) => {
 				iframeRef.current?.contentWindow?.postMessage(
 					{ type: 'UPDATE_CSS', payload: css },
-					'*'
+					targetOrigin
 				);
 			},
 			onError: (msg) => {

--- a/src/js/admin/sections/SettingsFields/FormPreview/index.tsx
+++ b/src/js/admin/sections/SettingsFields/FormPreview/index.tsx
@@ -27,7 +27,7 @@ export default function FormPreview() {
 			<PreviewHeader>
 				<PreviewTitleWrapper>
 					<p>{__('Live Preview', 'petitioner')}</p>
-					<small>{__('Note: this is not a perfect representation of your frontend, but its close', 'petitioner')}</small>
+					<small>{__('Note: this is not a perfect representation of your frontend, but it\'s close', 'petitioner')}</small>
 				</PreviewTitleWrapper>
 				{Array.isArray(petitions) && petitions.length > 0 && (
 					<PreviewSelect

--- a/src/js/admin/sections/SettingsFields/FormPreview/index.tsx
+++ b/src/js/admin/sections/SettingsFields/FormPreview/index.tsx
@@ -1,9 +1,6 @@
-import { useEffect, useRef, useState, useCallback } from '@wordpress/element';
-import { useSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
-import { useSettingsFormContext } from '@admin/context/SettingsContext';
-import { fetchPreviewCSS } from './utilities';
 import { PreviewCard, PreviewHeader, PreviewSelect, PreviewIframe } from './styled';
+import { useFormPreview } from './hooks'
 
 interface PetitionRecord {
 	id: number;
@@ -13,83 +10,23 @@ interface PetitionRecord {
 }
 
 export default function FormPreview() {
-	const { formState } = useSettingsFormContext();
-	const iframeRef = useRef<HTMLIFrameElement>(null);
-	const abortControllerRef = useRef<AbortController | null>(null);
-	const [iframeLoaded, setIframeLoaded] = useState(false);
-
-	const petitions = useSelect((select) => {
-		// @ts-ignore - core-data types might not be fully available
-		return select('core').getEntityRecords('postType', 'petitioner-petition', {
-			per_page: -1,
-		});
-	}, []);
-
-	const [selectedFormId, setSelectedFormId] = useState(0);
-
-	useEffect(() => {
-		if (Array.isArray(petitions) && petitions.length > 0 && selectedFormId === 0) {
-			setSelectedFormId(petitions[0].id);
-		}
-	}, [petitions, selectedFormId]);
-
-	const syncPreview = useCallback(async () => {
-		if (!iframeRef.current?.contentWindow) return;
-
-		const targetOrigin = new URL(
-			window.petitionerData?.home_url || '/',
-			window.location.href
-		).origin;
-
-		// 1. Send visibility updates instantly
-		iframeRef.current.contentWindow.postMessage(
-			{ type: 'UPDATE_VISIBILITY', payload: formState },
-			targetOrigin
-		);
-
-		// Cancel any pending CSS generation requests
-		if (abortControllerRef.current) {
-			abortControllerRef.current.abort();
-		}
-		abortControllerRef.current = new AbortController();
-
-		// 2. Fetch compiled CSS via AJAX
-		fetchPreviewCSS({
-			formState,
-			abortSignal: abortControllerRef.current.signal,
-			onSuccess: (css) => {
-				iframeRef.current?.contentWindow?.postMessage(
-					{ type: 'UPDATE_CSS', payload: css },
-					targetOrigin
-				);
-			},
-			onError: (msg) => {
-				console.error(msg);
-			},
-		});
-	}, [formState]);
-
-	// Sync settings to the iframe via AJAX + postMessage
-	useEffect(() => {
-		if (!iframeLoaded) return;
-
-		// Debounce the AJAX call
-		const timeout = setTimeout(() => {
-			syncPreview();
-		}, 300);
-
-		return () => clearTimeout(timeout);
-	}, [syncPreview, iframeLoaded]);
-
-	const previewUrl = `${window.petitionerData?.home_url || '/'}?petitioner_live_preview=1&form_id=${selectedFormId}`;
+	const {
+		iframeRef,
+		previewUrl,
+		selectedFormId,
+		petitions,
+		setIframeLoaded,
+		setSelectedFormId,
+		syncPreview,
+	} = useFormPreview();
 
 	return (
 		<PreviewCard>
 			<PreviewHeader>
 				<span>{__('Live Preview', 'petitioner')}</span>
 				{Array.isArray(petitions) && petitions.length > 0 && (
-					<PreviewSelect 
-						value={selectedFormId} 
+					<PreviewSelect
+						value={selectedFormId}
 						onChange={(e) => {
 							setIframeLoaded(false);
 							setSelectedFormId(Number(e.target.value));
@@ -101,9 +38,9 @@ export default function FormPreview() {
 					</PreviewSelect>
 				)}
 			</PreviewHeader>
-			<PreviewIframe 
+			<PreviewIframe
 				ref={iframeRef}
-				src={previewUrl} 
+				src={previewUrl}
 				onLoad={() => {
 					setIframeLoaded(true);
 					syncPreview();

--- a/src/js/admin/sections/SettingsFields/FormPreview/index.tsx
+++ b/src/js/admin/sections/SettingsFields/FormPreview/index.tsx
@@ -20,7 +20,7 @@ export default function FormPreview() {
 	const [selectedFormId, setSelectedFormId] = useState(0);
 
 	useEffect(() => {
-		if (petitions && petitions.length > 0 && selectedFormId === 0) {
+		if (Array.isArray(petitions) && petitions.length > 0 && selectedFormId === 0) {
 			setSelectedFormId(petitions[0].id);
 		}
 	}, [petitions, selectedFormId]);
@@ -72,7 +72,7 @@ export default function FormPreview() {
 		<PreviewCard>
 			<PreviewHeader>
 				<span>{__('Live Preview', 'petitioner')}</span>
-				{petitions && petitions.length > 0 && (
+				{Array.isArray(petitions) && petitions.length > 0 && (
 					<PreviewSelect 
 						value={selectedFormId} 
 						onChange={(e) => {

--- a/src/js/admin/sections/SettingsFields/FormPreview/index.tsx
+++ b/src/js/admin/sections/SettingsFields/FormPreview/index.tsx
@@ -1,15 +1,14 @@
 import { useEffect, useRef, useState, useCallback } from '@wordpress/element';
 import { useSelect } from '@wordpress/data';
-import { Spinner } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { useSettingsFormContext } from '@admin/context/SettingsContext';
+import { getAjaxNonce } from '@admin/utilities';
 import { PreviewCard, PreviewHeader, PreviewSelect, PreviewIframe } from './styled';
 
 export default function FormPreview() {
 	const { formState } = useSettingsFormContext();
 	const iframeRef = useRef<HTMLIFrameElement>(null);
 	const [iframeLoaded, setIframeLoaded] = useState(false);
-	const [isSyncing, setIsSyncing] = useState(false);
 
 	const petitions = useSelect((select) => {
 		// @ts-ignore - core-data types might not be fully available
@@ -35,27 +34,31 @@ export default function FormPreview() {
 			'*'
 		);
 
-		setIsSyncing(true);
-
 		// 2. Fetch compiled CSS via AJAX
 		try {
-			const formData = new URLSearchParams();
-			formData.append('action', 'petitioner_generate_preview_css');
+			const finalQuery = new URLSearchParams();
+			finalQuery.set('action', 'petitioner_generate_preview_css');
+
+			const finalData = new FormData();
 			// serialize formState as payload
 			Object.entries(formState).forEach(([key, value]) => {
 				if (value !== undefined && value !== null) {
-					formData.append(`payload[${key}]`, String(value));
+					finalData.append(`payload[${key}]`, String(value));
 				}
 			});
+			finalData.append('petitioner_nonce', getAjaxNonce());
 
-			const response = await fetch(ajaxurl, {
+			const request = await fetch(`${ajaxurl}?${finalQuery.toString()}`, {
 				method: 'POST',
-				body: formData,
-				headers: {
-					'Content-Type': 'application/x-www-form-urlencoded',
-				},
+				body: finalData,
 			});
-			const result = await response.json();
+			
+			if (!request.ok) {
+				console.error('HTTP error: ', request.status);
+				return;
+			}
+			
+			const result = await request.json();
 
 			if (result.success && result.data?.css) {
 				iframeRef.current.contentWindow.postMessage(
@@ -65,8 +68,6 @@ export default function FormPreview() {
 			}
 		} catch (e) {
 			console.error('Failed to update live preview CSS', e);
-		} finally {
-			setIsSyncing(false);
 		}
 	}, [formState]);
 
@@ -87,10 +88,7 @@ export default function FormPreview() {
 	return (
 		<PreviewCard>
 			<PreviewHeader>
-				<span style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
-					{__('Live Preview', 'petitioner')}
-					{(isSyncing || !iframeLoaded) && <Spinner />}
-				</span>
+				<span>{__('Live Preview', 'petitioner')}</span>
 				{petitions && petitions.length > 0 && (
 					<PreviewSelect 
 						value={selectedFormId} 

--- a/src/js/admin/sections/SettingsFields/FormPreview/index.tsx
+++ b/src/js/admin/sections/SettingsFields/FormPreview/index.tsx
@@ -1,13 +1,15 @@
-import { useEffect, useRef, useState } from '@wordpress/element';
+import { useEffect, useRef, useState, useCallback } from '@wordpress/element';
 import { useSelect } from '@wordpress/data';
+import { Spinner } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { useSettingsFormContext } from '@admin/context/SettingsContext';
 import { PreviewCard, PreviewHeader, PreviewSelect, PreviewIframe } from './styled';
-import { PREVIEW_UPDATE_EVENT } from './consts';
 
 export default function FormPreview() {
 	const { formState } = useSettingsFormContext();
 	const iframeRef = useRef<HTMLIFrameElement>(null);
+	const [iframeLoaded, setIframeLoaded] = useState(false);
+	const [isSyncing, setIsSyncing] = useState(false);
 
 	const petitions = useSelect((select) => {
 		// @ts-ignore - core-data types might not be fully available
@@ -24,26 +26,78 @@ export default function FormPreview() {
 		}
 	}, [petitions, selectedFormId]);
 
-	// Sync settings to the iframe via postMessage
-	useEffect(() => {
-		if (iframeRef.current && iframeRef.current.contentWindow) {
-			iframeRef.current.contentWindow.postMessage(
-				{ type: PREVIEW_UPDATE_EVENT, payload: formState },
-				'*'
-			);
+	const syncPreview = useCallback(async () => {
+		if (!iframeRef.current?.contentWindow) return;
+
+		// 1. Send visibility updates instantly
+		iframeRef.current.contentWindow.postMessage(
+			{ type: 'UPDATE_VISIBILITY', payload: formState },
+			'*'
+		);
+
+		setIsSyncing(true);
+
+		// 2. Fetch compiled CSS via AJAX
+		try {
+			const formData = new URLSearchParams();
+			formData.append('action', 'petitioner_generate_preview_css');
+			// serialize formState as payload
+			Object.entries(formState).forEach(([key, value]) => {
+				if (value !== undefined && value !== null) {
+					formData.append(`payload[${key}]`, String(value));
+				}
+			});
+
+			const response = await fetch(ajaxurl, {
+				method: 'POST',
+				body: formData,
+				headers: {
+					'Content-Type': 'application/x-www-form-urlencoded',
+				},
+			});
+			const result = await response.json();
+
+			if (result.success && result.data?.css) {
+				iframeRef.current.contentWindow.postMessage(
+					{ type: 'UPDATE_CSS', payload: result.data.css },
+					'*'
+				);
+			}
+		} catch (e) {
+			console.error('Failed to update live preview CSS', e);
+		} finally {
+			setIsSyncing(false);
 		}
 	}, [formState]);
+
+	// Sync settings to the iframe via AJAX + postMessage
+	useEffect(() => {
+		if (!iframeLoaded) return;
+
+		// Debounce the AJAX call
+		const timeout = setTimeout(() => {
+			syncPreview();
+		}, 300);
+
+		return () => clearTimeout(timeout);
+	}, [syncPreview, iframeLoaded]);
 
 	const previewUrl = `${window.petitionerData?.home_url || '/'}?petitioner_live_preview=1&form_id=${selectedFormId}`;
 
 	return (
 		<PreviewCard>
 			<PreviewHeader>
-				<span>{__('Live Preview', 'petitioner')}</span>
+				<span style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
+					{__('Live Preview', 'petitioner')}
+					{(isSyncing || !iframeLoaded) && <Spinner />}
+				</span>
 				{petitions && petitions.length > 0 && (
 					<PreviewSelect 
 						value={selectedFormId} 
-						onChange={(e) => setSelectedFormId(Number(e.target.value))}
+						onChange={(e) => {
+							setIframeLoaded(false);
+							setSelectedFormId(Number(e.target.value));
+						}}
 					>
 						{petitions.map((p: any) => (
 							<option key={p.id} value={p.id}>{p.title?.rendered || __('(No Title)', 'petitioner')}</option>
@@ -55,13 +109,8 @@ export default function FormPreview() {
 				ref={iframeRef}
 				src={previewUrl} 
 				onLoad={() => {
-					// Trigger initial sync once iframe loads
-					if (iframeRef.current?.contentWindow) {
-						iframeRef.current.contentWindow.postMessage(
-							{ type: PREVIEW_UPDATE_EVENT, payload: formState },
-							'*'
-						);
-					}
+					setIframeLoaded(true);
+					syncPreview();
 				}}
 			/>
 		</PreviewCard>

--- a/src/js/admin/sections/SettingsFields/FormPreview/index.tsx
+++ b/src/js/admin/sections/SettingsFields/FormPreview/index.tsx
@@ -5,6 +5,13 @@ import { useSettingsFormContext } from '@admin/context/SettingsContext';
 import { fetchPreviewCSS } from './utilities';
 import { PreviewCard, PreviewHeader, PreviewSelect, PreviewIframe } from './styled';
 
+interface PetitionRecord {
+	id: number;
+	title?: {
+		rendered: string;
+	};
+}
+
 export default function FormPreview() {
 	const { formState } = useSettingsFormContext();
 	const iframeRef = useRef<HTMLIFrameElement>(null);
@@ -14,7 +21,7 @@ export default function FormPreview() {
 	const petitions = useSelect((select) => {
 		// @ts-ignore - core-data types might not be fully available
 		return select('core').getEntityRecords('postType', 'petitioner-petition', {
-			per_page: 10,
+			per_page: -1,
 		});
 	}, []);
 
@@ -88,7 +95,7 @@ export default function FormPreview() {
 							setSelectedFormId(Number(e.target.value));
 						}}
 					>
-						{petitions.map((p: any) => (
+						{petitions.map((p: PetitionRecord) => (
 							<option key={p.id} value={p.id}>{p.title?.rendered || __('(No Title)', 'petitioner')}</option>
 						))}
 					</PreviewSelect>

--- a/src/js/admin/sections/SettingsFields/FormPreview/index.tsx
+++ b/src/js/admin/sections/SettingsFields/FormPreview/index.tsx
@@ -1,10 +1,12 @@
 import { __ } from '@wordpress/i18n';
 import { PreviewCard, PreviewHeader, PreviewSelect, PreviewIframe, PreviewTitleWrapper } from './styled';
 import { useFormPreview } from './hooks'
+import { decodeEntities } from '@wordpress/html-entities';
+
 
 type PetitionRecord = {
 	id: number;
-	title?: {
+	title: {
 		rendered: string;
 	};
 }
@@ -35,7 +37,7 @@ export default function FormPreview() {
 						}}
 					>
 						{petitions.map((p: PetitionRecord) => (
-							<option key={p.id} value={p.id}>{p.title?.rendered || __('(No Title)', 'petitioner')}</option>
+							<option key={p.id} value={p.id}>{decodeEntities(p.title.rendered) || __('(No Title)', 'petitioner')}</option>
 						))}
 					</PreviewSelect>
 				)}

--- a/src/js/admin/sections/SettingsFields/FormPreview/index.tsx
+++ b/src/js/admin/sections/SettingsFields/FormPreview/index.tsx
@@ -34,7 +34,7 @@ export default function FormPreview() {
 		}
 	}, [formState]);
 
-	const previewUrl = `${ajaxurl}?action=petitioner_live_preview&form_id=${selectedFormId}`;
+	const previewUrl = `${window.petitionerData?.home_url || '/'}?petitioner_live_preview=1&form_id=${selectedFormId}`;
 
 	return (
 		<PreviewCard>

--- a/src/js/admin/sections/SettingsFields/FormPreview/index.tsx
+++ b/src/js/admin/sections/SettingsFields/FormPreview/index.tsx
@@ -1,5 +1,5 @@
 import { __ } from '@wordpress/i18n';
-import { PreviewCard, PreviewHeader, PreviewSelect, PreviewIframe } from './styled';
+import { PreviewCard, PreviewHeader, PreviewSelect, PreviewIframe, PreviewTitleWrapper } from './styled';
 import { useFormPreview } from './hooks'
 
 interface PetitionRecord {
@@ -16,20 +16,22 @@ export default function FormPreview() {
 		selectedFormId,
 		petitions,
 		setIframeLoaded,
-		setSelectedFormId,
+		onFormSelect,
 		syncPreview,
 	} = useFormPreview();
 
 	return (
 		<PreviewCard>
 			<PreviewHeader>
-				<span>{__('Live Preview', 'petitioner')}</span>
+				<PreviewTitleWrapper>
+					<p>{__('Live Preview', 'petitioner')}</p>
+					<small>{__('Note: this is not a perfect representation of your frontend, but its close', 'petitioner')}</small>
+				</PreviewTitleWrapper>
 				{Array.isArray(petitions) && petitions.length > 0 && (
 					<PreviewSelect
 						value={selectedFormId}
 						onChange={(e) => {
-							setIframeLoaded(false);
-							setSelectedFormId(Number(e.target.value));
+							onFormSelect(Number(e.target.value));
 						}}
 					>
 						{petitions.map((p: PetitionRecord) => (

--- a/src/js/admin/sections/SettingsFields/FormPreview/index.tsx
+++ b/src/js/admin/sections/SettingsFields/FormPreview/index.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState } from '@wordpress/element';
+import { useSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import { useSettingsFormContext } from '@admin/context/SettingsContext';
 import { PreviewCard, PreviewHeader, PreviewSelect, PreviewIframe } from './styled';
@@ -7,8 +8,21 @@ import { PREVIEW_UPDATE_EVENT } from './consts';
 export default function FormPreview() {
 	const { formState } = useSettingsFormContext();
 	const iframeRef = useRef<HTMLIFrameElement>(null);
-	const petitions = window.petitionerData?.petitions || [];
-	const [selectedFormId, setSelectedFormId] = useState(petitions.length > 0 ? petitions[0].id : 0);
+
+	const petitions = useSelect((select) => {
+		// @ts-ignore - core-data types might not be fully available
+		return select('core').getEntityRecords('postType', 'petitioner-petition', {
+			per_page: 10,
+		});
+	}, []);
+
+	const [selectedFormId, setSelectedFormId] = useState(0);
+
+	useEffect(() => {
+		if (petitions && petitions.length > 0 && selectedFormId === 0) {
+			setSelectedFormId(petitions[0].id);
+		}
+	}, [petitions, selectedFormId]);
 
 	// Sync settings to the iframe via postMessage
 	useEffect(() => {
@@ -26,13 +40,13 @@ export default function FormPreview() {
 		<PreviewCard>
 			<PreviewHeader>
 				<span>{__('Live Preview', 'petitioner')}</span>
-				{petitions.length > 0 && (
+				{petitions && petitions.length > 0 && (
 					<PreviewSelect 
 						value={selectedFormId} 
 						onChange={(e) => setSelectedFormId(Number(e.target.value))}
 					>
-						{petitions.map((p) => (
-							<option key={p.id} value={p.id}>{p.title}</option>
+						{petitions.map((p: any) => (
+							<option key={p.id} value={p.id}>{p.title?.rendered || __('(No Title)', 'petitioner')}</option>
 						))}
 					</PreviewSelect>
 				)}

--- a/src/js/admin/sections/SettingsFields/FormPreview/index.tsx
+++ b/src/js/admin/sections/SettingsFields/FormPreview/index.tsx
@@ -2,7 +2,7 @@ import { __ } from '@wordpress/i18n';
 import { PreviewCard, PreviewHeader, PreviewSelect, PreviewIframe, PreviewTitleWrapper } from './styled';
 import { useFormPreview } from './hooks'
 
-interface PetitionRecord {
+type PetitionRecord = {
 	id: number;
 	title?: {
 		rendered: string;

--- a/src/js/admin/sections/SettingsFields/FormPreview/index.tsx
+++ b/src/js/admin/sections/SettingsFields/FormPreview/index.tsx
@@ -2,7 +2,7 @@ import { useEffect, useRef, useState, useCallback } from '@wordpress/element';
 import { useSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import { useSettingsFormContext } from '@admin/context/SettingsContext';
-import { getAjaxNonce } from '@admin/utilities';
+import { fetchPreviewCSS } from './utilities';
 import { PreviewCard, PreviewHeader, PreviewSelect, PreviewIframe } from './styled';
 
 export default function FormPreview() {
@@ -35,40 +35,18 @@ export default function FormPreview() {
 		);
 
 		// 2. Fetch compiled CSS via AJAX
-		try {
-			const finalQuery = new URLSearchParams();
-			finalQuery.set('action', 'petitioner_generate_preview_css');
-
-			const finalData = new FormData();
-			// serialize formState as payload
-			Object.entries(formState).forEach(([key, value]) => {
-				if (value !== undefined && value !== null) {
-					finalData.append(`payload[${key}]`, String(value));
-				}
-			});
-			finalData.append('petitioner_nonce', getAjaxNonce());
-
-			const request = await fetch(`${ajaxurl}?${finalQuery.toString()}`, {
-				method: 'POST',
-				body: finalData,
-			});
-			
-			if (!request.ok) {
-				console.error('HTTP error: ', request.status);
-				return;
-			}
-			
-			const result = await request.json();
-
-			if (result.success && result.data?.css) {
-				iframeRef.current.contentWindow.postMessage(
-					{ type: 'UPDATE_CSS', payload: result.data.css },
+		fetchPreviewCSS({
+			formState,
+			onSuccess: (css) => {
+				iframeRef.current?.contentWindow?.postMessage(
+					{ type: 'UPDATE_CSS', payload: css },
 					'*'
 				);
-			}
-		} catch (e) {
-			console.error('Failed to update live preview CSS', e);
-		}
+			},
+			onError: (msg) => {
+				console.error(msg);
+			},
+		});
 	}, [formState]);
 
 	// Sync settings to the iframe via AJAX + postMessage

--- a/src/js/admin/sections/SettingsFields/FormPreview/index.tsx
+++ b/src/js/admin/sections/SettingsFields/FormPreview/index.tsx
@@ -37,7 +37,7 @@ export default function FormPreview() {
 						}}
 					>
 						{petitions.map((p: PetitionRecord) => (
-							<option key={p.id} value={p.id}>{decodeEntities(p.title.rendered) || __('(No Title)', 'petitioner')}</option>
+							<option key={p.id} value={p.id}>{decodeEntities(p.title?.rendered || '') || __('(No Title)', 'petitioner')}</option>
 						))}
 					</PreviewSelect>
 				)}

--- a/src/js/admin/sections/SettingsFields/FormPreview/styled.tsx
+++ b/src/js/admin/sections/SettingsFields/FormPreview/styled.tsx
@@ -24,7 +24,7 @@ export const PreviewSelect = styled.select`
 
 export const PreviewIframe = styled.iframe`
 	width: 100%;
-	height: 700px;
+	min-height: 800px;
 	border: none;
 	display: block;
 `;

--- a/src/js/admin/sections/SettingsFields/FormPreview/styled.tsx
+++ b/src/js/admin/sections/SettingsFields/FormPreview/styled.tsx
@@ -1,4 +1,4 @@
-import { SPACINGS, COLORS } from '@admin/theme';
+import { SPACINGS, COLORS, BREAKPOINTS } from '@admin/theme';
 import styled from 'styled-components';
 
 export const PreviewCard = styled.div`
@@ -6,6 +6,11 @@ export const PreviewCard = styled.div`
 	border-radius: var(--ptr-admin-wrapper-radius);
 	background: #fff;
 	overflow: hidden;
+	display: none;
+
+	@media (min-width: ${BREAKPOINTS.lg}px) {
+		display: block;
+	}
 `;
 
 export const PreviewHeader = styled.div`

--- a/src/js/admin/sections/SettingsFields/FormPreview/styled.tsx
+++ b/src/js/admin/sections/SettingsFields/FormPreview/styled.tsx
@@ -1,17 +1,16 @@
 import styled from 'styled-components';
 
 export const PreviewCard = styled.div`
-	border: 1px solid #ddd;
-	border-radius: 4px;
+	border: 1px solid var(--ptr-admin-color-grey);
+	border-radius: var(--ptr-admin-wrapper-radius);
 	background: #fff;
 	overflow: hidden;
-	box-shadow: 0 1px 3px rgba(0,0,0,0.05);
 `;
 
 export const PreviewHeader = styled.div`
-	padding: 10px 15px;
-	background: #f6f7f7;
-	border-bottom: 1px solid #ddd;
+	padding: var(--ptr-admin-spacing-md) var(--ptr-admin-spacing-lg);
+	background: var(--ptr-admin-color-light);
+	border-bottom: 1px solid var(--ptr-admin-color-grey);
 	font-weight: 600;
 	display: flex;
 	justify-content: space-between;

--- a/src/js/admin/sections/SettingsFields/FormPreview/styled.tsx
+++ b/src/js/admin/sections/SettingsFields/FormPreview/styled.tsx
@@ -1,20 +1,21 @@
+import { SPACINGS, COLORS } from '@admin/theme';
 import styled from 'styled-components';
 
 export const PreviewCard = styled.div`
-	border: 1px solid var(--ptr-admin-color-grey);
+	border: 1px solid ${COLORS.grey};
 	border-radius: var(--ptr-admin-wrapper-radius);
 	background: #fff;
 	overflow: hidden;
 `;
 
 export const PreviewHeader = styled.div`
-	padding: var(--ptr-admin-spacing-md) var(--ptr-admin-spacing-lg);
-	background: var(--ptr-admin-color-light);
-	border-bottom: 1px solid var(--ptr-admin-color-grey);
+	padding: ${SPACINGS.md} ${SPACINGS.lg};
+	background: ${COLORS.light};
+	border-bottom: 1px solid ${COLORS.grey};
 	font-weight: 600;
 	display: flex;
 	justify-content: space-between;
-	align-items: center;
+	align-items: flex-end;
 `;
 
 export const PreviewSelect = styled.select`
@@ -27,4 +28,11 @@ export const PreviewIframe = styled.iframe`
 	min-height: 800px;
 	border: none;
 	display: block;
+`;
+
+export const PreviewTitleWrapper = styled.div`
+	display: flex;
+	flex-direction: column;
+	gap: 0;
+	color: ${COLORS.dark};
 `;

--- a/src/js/admin/sections/SettingsFields/FormPreview/styled.tsx
+++ b/src/js/admin/sections/SettingsFields/FormPreview/styled.tsx
@@ -1,0 +1,31 @@
+import styled from 'styled-components';
+
+export const PreviewCard = styled.div`
+	border: 1px solid #ddd;
+	border-radius: 4px;
+	background: #fff;
+	overflow: hidden;
+	box-shadow: 0 1px 3px rgba(0,0,0,0.05);
+`;
+
+export const PreviewHeader = styled.div`
+	padding: 10px 15px;
+	background: #f6f7f7;
+	border-bottom: 1px solid #ddd;
+	font-weight: 600;
+	display: flex;
+	justify-content: space-between;
+	align-items: center;
+`;
+
+export const PreviewSelect = styled.select`
+	max-width: 150px;
+	font-size: 13px;
+`;
+
+export const PreviewIframe = styled.iframe`
+	width: 100%;
+	height: 700px;
+	border: none;
+	display: block;
+`;

--- a/src/js/admin/sections/SettingsFields/FormPreview/utilities.ts
+++ b/src/js/admin/sections/SettingsFields/FormPreview/utilities.ts
@@ -1,4 +1,3 @@
-import { getAjaxNonce } from '@admin/utilities';
 import type { SettingsFormData } from '@admin/sections/SettingsFields/consts';
 
 interface FetchPreviewCSSSettings {
@@ -23,7 +22,7 @@ export const fetchPreviewCSS = async ({
 				finalData.append(`payload[${key}]`, String(value));
 			}
 		});
-		finalData.append('petitioner_nonce', getAjaxNonce());
+		finalData.append('petitioner_nonce', String(window.petitionerData.preview_nonce));
 
 		const request = await fetch(`${ajaxurl}?${finalQuery.toString()}`, {
 			method: 'POST',

--- a/src/js/admin/sections/SettingsFields/FormPreview/utilities.ts
+++ b/src/js/admin/sections/SettingsFields/FormPreview/utilities.ts
@@ -56,7 +56,3 @@ export const localGetSavedFormId = (): number | null => {
 export const localSaveFormID = (id: number) => {
 	window.localStorage.setItem(LOCAL_STORAGE_KEY, String(id));
 }
-
-export const localClearSavedFormID = () => {
-	window.localStorage.removeItem(LOCAL_STORAGE_KEY);
-}

--- a/src/js/admin/sections/SettingsFields/FormPreview/utilities.ts
+++ b/src/js/admin/sections/SettingsFields/FormPreview/utilities.ts
@@ -1,0 +1,48 @@
+import { getAjaxNonce } from '@admin/utilities';
+import type { SettingsFormData } from '@admin/sections/SettingsFields/consts';
+
+interface FetchPreviewCSSSettings {
+	formState: SettingsFormData;
+	onSuccess?: (css: string) => void;
+	onError?: (msg: string) => void;
+}
+
+export const fetchPreviewCSS = async ({
+	formState,
+	onSuccess = () => {},
+	onError = () => {},
+}: FetchPreviewCSSSettings) => {
+	try {
+		const finalQuery = new URLSearchParams();
+		finalQuery.set('action', 'petitioner_generate_preview_css');
+
+		const finalData = new FormData();
+		// serialize formState as payload
+		Object.entries(formState).forEach(([key, value]) => {
+			if (value !== undefined && value !== null) {
+				finalData.append(`payload[${key}]`, String(value));
+			}
+		});
+		finalData.append('petitioner_nonce', getAjaxNonce());
+
+		const request = await fetch(`${ajaxurl}?${finalQuery.toString()}`, {
+			method: 'POST',
+			body: finalData,
+		});
+
+		if (!request.ok) {
+			onError('HTTP error: ' + request.status);
+			return;
+		}
+
+		const result = await request.json();
+
+		if (result.success && result.data?.css) {
+			onSuccess(result.data.css);
+		} else {
+			onError('Failed to generate preview CSS');
+		}
+	} catch (error) {
+		onError('Error generating preview CSS: ' + error);
+	}
+};

--- a/src/js/admin/sections/SettingsFields/FormPreview/utilities.ts
+++ b/src/js/admin/sections/SettingsFields/FormPreview/utilities.ts
@@ -1,26 +1,26 @@
 import type { SettingsFormData } from '@admin/sections/SettingsFields/consts';
 import { LOCAL_STORAGE_KEY } from './consts';
 
-type FetchPreviewCSSSettings = {
-	formState: SettingsFormData;
-	onSuccess?: (css: string) => void;
-	onError?: (msg: string) => void;
-	abortSignal?: AbortSignal;
-}
-
 export const fetchPreviewCSS = async ({
 	formState,
+	previewNonce,
 	onSuccess = () => { },
 	onError = () => { },
 	abortSignal,
-}: FetchPreviewCSSSettings) => {
+}: {
+	formState: SettingsFormData;
+	previewNonce: string;
+	onSuccess?: (css: string) => void;
+	onError?: (msg: string) => void;
+	abortSignal?: AbortSignal;
+}) => {
 	try {
 		const finalQuery = new URLSearchParams();
 		finalQuery.set('action', 'petitioner_generate_preview_css');
 
 		const finalData = new FormData();
 		finalData.append('payload', JSON.stringify(formState));
-		finalData.append('petitioner_nonce', String(window.petitionerData.preview_nonce));
+		finalData.append('petitioner_nonce', previewNonce);
 
 		const request = await fetch(`${ajaxurl}?${finalQuery.toString()}`, {
 			method: 'POST',

--- a/src/js/admin/sections/SettingsFields/FormPreview/utilities.ts
+++ b/src/js/admin/sections/SettingsFields/FormPreview/utilities.ts
@@ -16,12 +16,7 @@ export const fetchPreviewCSS = async ({
 		finalQuery.set('action', 'petitioner_generate_preview_css');
 
 		const finalData = new FormData();
-		// serialize formState as payload
-		Object.entries(formState).forEach(([key, value]) => {
-			if (value !== undefined && value !== null) {
-				finalData.append(`payload[${key}]`, String(value));
-			}
-		});
+		finalData.append('payload', JSON.stringify(formState));
 		finalData.append('petitioner_nonce', String(window.petitionerData.preview_nonce));
 
 		const request = await fetch(`${ajaxurl}?${finalQuery.toString()}`, {

--- a/src/js/admin/sections/SettingsFields/FormPreview/utilities.ts
+++ b/src/js/admin/sections/SettingsFields/FormPreview/utilities.ts
@@ -4,12 +4,14 @@ interface FetchPreviewCSSSettings {
 	formState: SettingsFormData;
 	onSuccess?: (css: string) => void;
 	onError?: (msg: string) => void;
+	abortSignal?: AbortSignal;
 }
 
 export const fetchPreviewCSS = async ({
 	formState,
 	onSuccess = () => {},
 	onError = () => {},
+	abortSignal,
 }: FetchPreviewCSSSettings) => {
 	try {
 		const finalQuery = new URLSearchParams();
@@ -22,6 +24,7 @@ export const fetchPreviewCSS = async ({
 		const request = await fetch(`${ajaxurl}?${finalQuery.toString()}`, {
 			method: 'POST',
 			body: finalData,
+			signal: abortSignal,
 		});
 
 		if (!request.ok) {
@@ -37,6 +40,9 @@ export const fetchPreviewCSS = async ({
 			onError('Failed to generate preview CSS');
 		}
 	} catch (error) {
+		if (error instanceof DOMException && error.name === 'AbortError') {
+			return; // Silently ignore aborted requests
+		}
 		onError('Error generating preview CSS: ' + error);
 	}
 };

--- a/src/js/admin/sections/SettingsFields/FormPreview/utilities.ts
+++ b/src/js/admin/sections/SettingsFields/FormPreview/utilities.ts
@@ -57,5 +57,7 @@ export const localGetSavedFormId = () => {
 }
 
 export const localSaveFormID = (id: number) => {
+	if (Number.isNaN(id) || id <= 0) return;
+
 	window.localStorage.setItem(LOCAL_STORAGE_KEY, String(id));
 }

--- a/src/js/admin/sections/SettingsFields/FormPreview/utilities.ts
+++ b/src/js/admin/sections/SettingsFields/FormPreview/utilities.ts
@@ -1,4 +1,5 @@
 import type { SettingsFormData } from '@admin/sections/SettingsFields/consts';
+import { LOCAL_STORAGE_KEY } from './consts';
 
 interface FetchPreviewCSSSettings {
 	formState: SettingsFormData;
@@ -9,8 +10,8 @@ interface FetchPreviewCSSSettings {
 
 export const fetchPreviewCSS = async ({
 	formState,
-	onSuccess = () => {},
-	onError = () => {},
+	onSuccess = () => { },
+	onError = () => { },
 	abortSignal,
 }: FetchPreviewCSSSettings) => {
 	try {
@@ -46,3 +47,16 @@ export const fetchPreviewCSS = async ({
 		onError('Error generating preview CSS: ' + error);
 	}
 };
+
+export const localGetSavedFormId = (): number | null => {
+	const saved = window.localStorage.getItem(LOCAL_STORAGE_KEY);
+	return saved ? Number(saved) : null;
+}
+
+export const localSaveFormID = (id: number) => {
+	window.localStorage.setItem(LOCAL_STORAGE_KEY, String(id));
+}
+
+export const localClearSavedFormID = () => {
+	window.localStorage.removeItem(LOCAL_STORAGE_KEY);
+}

--- a/src/js/admin/sections/SettingsFields/FormPreview/utilities.ts
+++ b/src/js/admin/sections/SettingsFields/FormPreview/utilities.ts
@@ -1,7 +1,7 @@
 import type { SettingsFormData } from '@admin/sections/SettingsFields/consts';
 import { LOCAL_STORAGE_KEY } from './consts';
 
-interface FetchPreviewCSSSettings {
+type FetchPreviewCSSSettings = {
 	formState: SettingsFormData;
 	onSuccess?: (css: string) => void;
 	onError?: (msg: string) => void;

--- a/src/js/admin/sections/SettingsFields/FormPreview/utilities.ts
+++ b/src/js/admin/sections/SettingsFields/FormPreview/utilities.ts
@@ -48,9 +48,12 @@ export const fetchPreviewCSS = async ({
 	}
 };
 
-export const localGetSavedFormId = (): number | null => {
+export const localGetSavedFormId = () => {
 	const saved = window.localStorage.getItem(LOCAL_STORAGE_KEY);
-	return saved ? Number(saved) : null;
+	if (!saved) return null;
+
+	const parsed = Number(saved);
+	return Number.isNaN(parsed) ? null : parsed;
 }
 
 export const localSaveFormID = (id: number) => {

--- a/src/js/admin/sections/SettingsFields/VisualSettings.tsx
+++ b/src/js/admin/sections/SettingsFields/VisualSettings.tsx
@@ -16,7 +16,7 @@ export default function VisualSettings() {
 	const visualOptions = windowPetitionerData?.default_values?.visual_options || {};
 	
 	const formatOptions = (optionsObj: Record<string, string> = {}) => {
-		return Object.entries(optionsObj).map(([value, label]) => ({
+		return Object.entries(optionsObj || {}).map(([value, label]) => ({
 			label,
 			value,
 		}));

--- a/src/js/admin/sections/SettingsFields/VisualSettings.tsx
+++ b/src/js/admin/sections/SettingsFields/VisualSettings.tsx
@@ -2,6 +2,7 @@ import CodeEditor from '@admin/components/CodeEditor';
 import ColorField from '@admin/components/ColorField';
 import { useSettingsFormContext } from '@admin/context/SettingsContext';
 import { SelectControl } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
 
 export default function VisualSettings() {
 	const { formState, updateFormState, windowPetitionerData } = useSettingsFormContext();
@@ -26,7 +27,7 @@ export default function VisualSettings() {
 					}}
 				/>
 				<label htmlFor="petitioner_show_letter">
-					Show letter on the frontend?
+					{__('Show letter on the frontend?', 'petitioner')}
 				</label>
 			</p>
 			<p>
@@ -41,7 +42,7 @@ export default function VisualSettings() {
 					}}
 				/>
 				<label htmlFor="petitioner_show_title">
-					Show petition title?
+					{__('Show petition title?', 'petitioner')}
 				</label>
 			</p>
 			<p>
@@ -56,16 +57,16 @@ export default function VisualSettings() {
 					}}
 				/>
 				<label htmlFor="petitioner_show_goal">
-					Show petition goal?
+					{__('Show petition goal?', 'petitioner')}
 				</label>
 			</p>
 
 			<hr />
 
-			<h3 style={{ marginBottom: '0' }}>Colors</h3>
+			<h3 style={{ marginBottom: '0' }}>{__('Colors', 'petitioner')}</h3>
 			<div className="ptr-field-panel">
 				<div>
-					<label>Primary color</label>
+					<label>{__('Primary color', 'petitioner')}</label>
 				</div>
 				<ColorField
 					id={'petitioner_primary_color'}
@@ -79,7 +80,7 @@ export default function VisualSettings() {
 
 			<div className="ptr-field-panel">
 				<div>
-					<label>Dark color</label>
+					<label>{__('Dark color', 'petitioner')}</label>
 				</div>
 				<ColorField
 					id={'petitioner_dark_color'}
@@ -93,7 +94,7 @@ export default function VisualSettings() {
 
 			<div className="ptr-field-panel">
 				<div>
-					<label>Grey color</label>
+					<label>{__('Grey color', 'petitioner')}</label>
 				</div>
 				<ColorField
 					id={'petitioner_grey_color'}
@@ -107,18 +108,18 @@ export default function VisualSettings() {
 
 			<hr />
 
-			<h3 style={{ marginBottom: '10px' }}>Layout & Sizing</h3>
+			<h3 style={{ marginBottom: '0' }}>{__('Layout & Sizing', 'petitioner')}</h3>
 			<div className="ptr-field-panel">
 				<SelectControl
-					label="Border Radius"
+					label={__('Border Radius', 'petitioner')}
 					value={formState?.border_radius || ''}
 					options={[
-						{ label: 'Default (8px)', value: '' },
-						{ label: 'Sharp (2px)', value: 'xs' },
-						{ label: 'Slightly Rounded (4px)', value: 'sm' },
-						{ label: 'Rounded (8px)', value: 'md' },
-						{ label: 'Very Rounded (16px)', value: 'lg' },
-						{ label: 'Pill (999px)', value: 'full' },
+						{ label: __('Default (8px)', 'petitioner'), value: '' },
+						{ label: __('Sharp (2px)', 'petitioner'), value: 'xs' },
+						{ label: __('Slightly Rounded (4px)', 'petitioner'), value: 'sm' },
+						{ label: __('Rounded (8px)', 'petitioner'), value: 'md' },
+						{ label: __('Very Rounded (16px)', 'petitioner'), value: 'lg' },
+						{ label: __('Pill (999px)', 'petitioner'), value: 'full' },
 					]}
 					onChange={(val) => updateFormState('border_radius', val)}
 				/>
@@ -127,13 +128,13 @@ export default function VisualSettings() {
 
 			<div className="ptr-field-panel">
 				<SelectControl
-					label="Form Font Size"
+					label={__('Form Font Size', 'petitioner')}
 					value={formState?.base_font_size || ''}
 					options={[
-						{ label: 'Default (14px)', value: '' },
-						{ label: 'Extra Small (12px)', value: 'xs' },
-						{ label: 'Small (14px)', value: 'sm' },
-						{ label: 'Medium (16px)', value: 'md' },
+						{ label: __('Default (14px)', 'petitioner'), value: '' },
+						{ label: __('Extra Small (12px)', 'petitioner'), value: 'xs' },
+						{ label: __('Small (14px)', 'petitioner'), value: 'sm' },
+						{ label: __('Medium (16px)', 'petitioner'), value: 'md' },
 					]}
 					onChange={(val) => updateFormState('base_font_size', val)}
 				/>
@@ -142,14 +143,14 @@ export default function VisualSettings() {
 
 			<div className="ptr-field-panel">
 				<SelectControl
-					label="Button Font Size"
+					label={__('Button Font Size', 'petitioner')}
 					value={formState?.button_font_size || ''}
 					options={[
-						{ label: 'Default (18px)', value: '' },
-						{ label: 'Extra Small (12px)', value: 'xs' },
-						{ label: 'Small (14px)', value: 'sm' },
-						{ label: 'Medium (16px)', value: 'md' },
-						{ label: 'Large (18px)', value: 'lg' },
+						{ label: __('Default (18px)', 'petitioner'), value: '' },
+						{ label: __('Extra Small (12px)', 'petitioner'), value: 'xs' },
+						{ label: __('Small (14px)', 'petitioner'), value: 'sm' },
+						{ label: __('Medium (16px)', 'petitioner'), value: 'md' },
+						{ label: __('Large (18px)', 'petitioner'), value: 'lg' },
 					]}
 					onChange={(val) => updateFormState('button_font_size', val)}
 				/>
@@ -158,14 +159,14 @@ export default function VisualSettings() {
 
 			<div className="ptr-field-panel">
 				<SelectControl
-					label="Input Border Thickness"
+					label={__('Input Border Thickness', 'petitioner')}
 					value={formState?.input_border_width || ''}
 					options={[
-						{ label: 'Default', value: '' },
-						{ label: '0px (None)', value: '0px' },
-						{ label: '1px', value: '1px' },
-						{ label: '2px', value: '2px' },
-						{ label: '3px', value: '3px' },
+						{ label: __('Default', 'petitioner'), value: '' },
+						{ label: __('0px (None)', 'petitioner'), value: '0px' },
+						{ label: __('1px', 'petitioner'), value: '1px' },
+						{ label: __('2px', 'petitioner'), value: '2px' },
+						{ label: __('3px', 'petitioner'), value: '3px' },
 					]}
 					onChange={(val) => updateFormState('input_border_width', val)}
 				/>
@@ -174,15 +175,15 @@ export default function VisualSettings() {
 
 			<div className="ptr-field-panel">
 				<SelectControl
-					label="Field Spacing"
+					label={__('Field Spacing', 'petitioner')}
 					value={formState?.field_spacing || ''}
 					options={[
-						{ label: 'Default (8px)', value: '' },
-						{ label: 'Extra Small (4px)', value: 'xs' },
-						{ label: 'Small (8px)', value: 'sm' },
-						{ label: 'Medium (16px)', value: 'md' },
-						{ label: 'Large (24px)', value: 'lg' },
-						{ label: 'Extra Large (32px)', value: 'xl' },
+						{ label: __('Default (8px)', 'petitioner'), value: '' },
+						{ label: __('Extra Small (4px)', 'petitioner'), value: 'xs' },
+						{ label: __('Small (8px)', 'petitioner'), value: 'sm' },
+						{ label: __('Medium (16px)', 'petitioner'), value: 'md' },
+						{ label: __('Large (24px)', 'petitioner'), value: 'lg' },
+						{ label: __('Extra Large (32px)', 'petitioner'), value: 'xl' },
 					]}
 					onChange={(val) => updateFormState('field_spacing', val)}
 				/>
@@ -191,14 +192,14 @@ export default function VisualSettings() {
 
 			<div className="ptr-field-panel">
 				<SelectControl
-					label="Input Size"
+					label={__('Input Size', 'petitioner')}
 					value={formState?.input_size || ''}
 					options={[
-						{ label: 'Default (~62px)', value: '' },
-						{ label: 'Small (32px)', value: 'sm' },
-						{ label: 'Regular (40px)', value: 'md' },
-						{ label: 'Large (48px)', value: 'lg' },
-						{ label: 'Extra Large (~62px)', value: 'xl' },
+						{ label: __('Default (~62px)', 'petitioner'), value: '' },
+						{ label: __('Small (32px)', 'petitioner'), value: 'sm' },
+						{ label: __('Regular (40px)', 'petitioner'), value: 'md' },
+						{ label: __('Large (48px)', 'petitioner'), value: 'lg' },
+						{ label: __('Extra Large (~62px)', 'petitioner'), value: 'xl' },
 					]}
 					onChange={(val) => updateFormState('input_size', val)}
 				/>
@@ -207,8 +208,8 @@ export default function VisualSettings() {
 
 			<CodeEditor
 				code={formState?.custom_css || ''}
-				title="Custom CSS"
-				help="Add your custom CSS here."
+				title={__('Custom CSS', 'petitioner')}
+				help={__('Add your custom CSS here.', 'petitioner')}
 			/>
 		</>
 	);

--- a/src/js/admin/sections/SettingsFields/VisualSettings.tsx
+++ b/src/js/admin/sections/SettingsFields/VisualSettings.tsx
@@ -4,7 +4,7 @@ import { useSettingsFormContext } from '@admin/context/SettingsContext';
 import { SelectControl } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import type { SettingsFormData } from './consts';
-import { VisualSettingsLayout, MainContent, SidebarContent, SizingGrid } from './styled';
+import { VisualSettingsLayout, MainContent, SidebarContent, SizingGrid, SecurityWarning } from './styled';
 import FormPreview from './FormPreview';
 
 export default function VisualSettings({ isActive }: { isActive?: boolean }) {
@@ -188,10 +188,15 @@ export default function VisualSettings({ isActive }: { isActive?: boolean }) {
 				<CodeEditor
 					code={formState?.custom_css || ''}
 					title={__('Custom CSS', 'petitioner')}
-					help={__('Add your custom CSS here.', 'petitioner')}
+					help={__('Add your custom CSS here. Note: <style> tags are not needed.', 'petitioner')}
 					onChange={(val) => updateFormState('custom_css', val)}
 					isActive={isActive}
 				/>
+				{formState?.custom_css?.match(/<\s*\/?\s*style[^>]*>/i) && (
+					<SecurityWarning>
+						<strong>{__('Note:', 'petitioner')}</strong> {__('<style> tags are automatically stripped from output for security reasons. Please write pure CSS.', 'petitioner')}
+					</SecurityWarning>
+				)}
 			</MainContent>
 			<SidebarContent>
 				<FormPreview />

--- a/src/js/admin/sections/SettingsFields/VisualSettings.tsx
+++ b/src/js/admin/sections/SettingsFields/VisualSettings.tsx
@@ -192,7 +192,7 @@ export default function VisualSettings({ isActive }: { isActive?: boolean }) {
 					onChange={(val) => updateFormState('custom_css', val)}
 					isActive={isActive}
 				/>
-				{formState?.custom_css?.match(/<\s*\/?\s*style[^>]*>/i) && (
+				{formState?.custom_css?.match(/<\s*\/?\s*style\b[^>]*>?/i) && (
 					<SecurityWarning>
 						<strong>{__('Note:', 'petitioner')}</strong> {__('<style> tags are automatically stripped from output for security reasons. Please write pure CSS.', 'petitioner')}
 					</SecurityWarning>

--- a/src/js/admin/sections/SettingsFields/VisualSettings.tsx
+++ b/src/js/admin/sections/SettingsFields/VisualSettings.tsx
@@ -4,7 +4,7 @@ import { useSettingsFormContext } from '@admin/context/SettingsContext';
 import { SelectControl } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import type { SettingsFormData } from './consts';
-import { VisualSettingsLayout, MainContent, SidebarContent } from './styled';
+import { VisualSettingsLayout, MainContent, SidebarContent, SizingGrid } from './styled';
 import FormPreview from './FormPreview';
 
 export default function VisualSettings({ isActive }: { isActive?: boolean }) {
@@ -17,7 +17,7 @@ export default function VisualSettings({ isActive }: { isActive?: boolean }) {
 	};
 
 	const visualOptions = windowPetitionerData?.default_values?.visual_options || {};
-	
+
 	const formatOptions = (optionsObj: Record<string, string> = {}) => {
 		return Object.entries(optionsObj || {}).map(([value, label]) => ({
 			label,
@@ -28,167 +28,170 @@ export default function VisualSettings({ isActive }: { isActive?: boolean }) {
 	return (
 		<VisualSettingsLayout>
 			<MainContent>
-			<p>
-				<input
-					checked={formState.show_letter}
-					type="checkbox"
-					name="petitioner_show_letter"
-					id="petitioner_show_letter"
-					className="widefat"
-					onChange={(e) => {
-						updateFormState('show_letter', e.target.checked);
-					}}
-				/>
-				<label htmlFor="petitioner_show_letter">
-					{__('Show letter on the frontend?', 'petitioner')}
-				</label>
-			</p>
-			<p>
-				<input
-					checked={formState.show_title}
-					type="checkbox"
-					name="petitioner_show_title"
-					id="petitioner_show_title"
-					className="widefat"
-					onChange={(e) => {
-						updateFormState('show_title', e.target.checked);
-					}}
-				/>
-				<label htmlFor="petitioner_show_title">
-					{__('Show petition title?', 'petitioner')}
-				</label>
-			</p>
-			<p>
-				<input
-					checked={formState.show_goal}
-					type="checkbox"
-					name="petitioner_show_goal"
-					id="petitioner_show_goal"
-					className="widefat"
-					onChange={(e) => {
-						updateFormState('show_goal', e.target.checked);
-					}}
-				/>
-				<label htmlFor="petitioner_show_goal">
-					{__('Show petition goal?', 'petitioner')}
-				</label>
-			</p>
+				<p>
+					<input
+						checked={formState.show_letter}
+						type="checkbox"
+						name="petitioner_show_letter"
+						id="petitioner_show_letter"
+						className="widefat"
+						onChange={(e) => {
+							updateFormState('show_letter', e.target.checked);
+						}}
+					/>
+					<label htmlFor="petitioner_show_letter">
+						{__('Show letter on the frontend?', 'petitioner')}
+					</label>
+				</p>
+				<p>
+					<input
+						checked={formState.show_title}
+						type="checkbox"
+						name="petitioner_show_title"
+						id="petitioner_show_title"
+						className="widefat"
+						onChange={(e) => {
+							updateFormState('show_title', e.target.checked);
+						}}
+					/>
+					<label htmlFor="petitioner_show_title">
+						{__('Show petition title?', 'petitioner')}
+					</label>
+				</p>
+				<p>
+					<input
+						checked={formState.show_goal}
+						type="checkbox"
+						name="petitioner_show_goal"
+						id="petitioner_show_goal"
+						className="widefat"
+						onChange={(e) => {
+							updateFormState('show_goal', e.target.checked);
+						}}
+					/>
+					<label htmlFor="petitioner_show_goal">
+						{__('Show petition goal?', 'petitioner')}
+					</label>
+				</p>
 
-			<hr />
+				<hr />
 
-			<h3 style={{ marginBottom: '0' }}>{__('Colors', 'petitioner')}</h3>
-			<div className="ptr-field-panel">
-				<div>
-					<label>{__('Primary color', 'petitioner')}</label>
+				<h3 style={{ marginBottom: '0' }}>{__('Colors', 'petitioner')}</h3>
+				<div className="ptr-field-panel">
+					<div>
+						<label>{__('Primary color', 'petitioner')}</label>
+					</div>
+					<ColorField
+						id={'petitioner_primary_color'}
+						color={formState?.primary_color}
+						defaultColor={defaultColors?.primary}
+						onColorChange={(newColor: string) =>
+							updateFormState('primary_color', newColor)
+						}
+					/>
 				</div>
-				<ColorField
-					id={'petitioner_primary_color'}
-					color={formState?.primary_color}
-					defaultColor={defaultColors?.primary}
-					onColorChange={(newColor: string) =>
-						updateFormState('primary_color', newColor)
-					}
-				/>
-			</div>
 
-			<div className="ptr-field-panel">
-				<div>
-					<label>{__('Dark color', 'petitioner')}</label>
+				<div className="ptr-field-panel">
+					<div>
+						<label>{__('Dark color', 'petitioner')}</label>
+					</div>
+					<ColorField
+						id={'petitioner_dark_color'}
+						color={formState?.dark_color}
+						defaultColor={defaultColors?.dark}
+						onColorChange={(newColor: string) =>
+							updateFormState('dark_color', newColor)
+						}
+					/>
 				</div>
-				<ColorField
-					id={'petitioner_dark_color'}
-					color={formState?.dark_color}
-					defaultColor={defaultColors?.dark}
-					onColorChange={(newColor: string) =>
-						updateFormState('dark_color', newColor)
-					}
-				/>
-			</div>
 
-			<div className="ptr-field-panel">
-				<div>
-					<label>{__('Grey color', 'petitioner')}</label>
+				<div className="ptr-field-panel">
+					<div>
+						<label>{__('Grey color', 'petitioner')}</label>
+					</div>
+					<ColorField
+						id={'petitioner_grey_color'}
+						color={formState?.grey_color}
+						defaultColor={defaultColors?.grey}
+						onColorChange={(newColor: string) =>
+							updateFormState('grey_color', newColor)
+						}
+					/>
 				</div>
-				<ColorField
-					id={'petitioner_grey_color'}
-					color={formState?.grey_color}
-					defaultColor={defaultColors?.grey}
-					onColorChange={(newColor: string) =>
-						updateFormState('grey_color', newColor)
-					}
+
+				<hr />
+
+				<h3 style={{ marginBottom: '0' }}>{__('Layout & Sizing', 'petitioner')}</h3>
+				<SizingGrid>
+					<div className="ptr-field-panel">
+						<SelectControl
+							label={__('Border Radius', 'petitioner')}
+							value={formState?.border_radius || ''}
+							options={formatOptions(visualOptions.border_radius)}
+							onChange={(val) => updateFormState('border_radius', val as SettingsFormData['border_radius'])}
+						/>
+						<input type="hidden" name="petitioner_border_radius" value={formState?.border_radius || ''} />
+					</div>
+
+					<div className="ptr-field-panel">
+						<SelectControl
+							label={__('Form Font Size', 'petitioner')}
+							value={formState?.base_font_size || ''}
+							options={formatOptions(visualOptions.base_font_size)}
+							onChange={(val) => updateFormState('base_font_size', val as SettingsFormData['base_font_size'])}
+						/>
+						<input type="hidden" name="petitioner_base_font_size" value={formState?.base_font_size || ''} />
+					</div>
+
+					<div className="ptr-field-panel">
+						<SelectControl
+							label={__('Button Font Size', 'petitioner')}
+							value={formState?.button_font_size || ''}
+							options={formatOptions(visualOptions.button_font_size)}
+							onChange={(val) => updateFormState('button_font_size', val as SettingsFormData['button_font_size'])}
+						/>
+						<input type="hidden" name="petitioner_button_font_size" value={formState?.button_font_size || ''} />
+					</div>
+
+					<div className="ptr-field-panel">
+						<SelectControl
+							label={__('Input Border Thickness', 'petitioner')}
+							value={formState?.input_border_width || ''}
+							options={formatOptions(visualOptions.input_border_width)}
+							onChange={(val) => updateFormState('input_border_width', val as SettingsFormData['input_border_width'])}
+						/>
+						<input type="hidden" name="petitioner_input_border_width" value={formState?.input_border_width || ''} />
+					</div>
+
+					<div className="ptr-field-panel">
+						<SelectControl
+							label={__('Field Spacing', 'petitioner')}
+							value={formState?.field_spacing || ''}
+							options={formatOptions(visualOptions.field_spacing)}
+							onChange={(val) => updateFormState('field_spacing', val as SettingsFormData['field_spacing'])}
+						/>
+						<input type="hidden" name="petitioner_field_spacing" value={formState?.field_spacing || ''} />
+					</div>
+
+					<div className="ptr-field-panel">
+						<SelectControl
+							label={__('Input Size', 'petitioner')}
+							value={formState?.input_size || ''}
+							options={formatOptions(visualOptions.input_size)}
+							onChange={(val) => updateFormState('input_size', val as SettingsFormData['input_size'])}
+						/>
+						<input type="hidden" name="petitioner_input_size" value={formState?.input_size || ''} />
+					</div>
+
+				</SizingGrid>
+
+				<CodeEditor
+					code={formState?.custom_css || ''}
+					title={__('Custom CSS', 'petitioner')}
+					help={__('Add your custom CSS here.', 'petitioner')}
+					onChange={(val) => updateFormState('custom_css', val)}
+					isActive={isActive}
 				/>
-			</div>
-
-			<hr />
-
-			<h3 style={{ marginBottom: '0' }}>{__('Layout & Sizing', 'petitioner')}</h3>
-			<div className="ptr-field-panel">
-				<SelectControl
-					label={__('Border Radius', 'petitioner')}
-					value={formState?.border_radius || ''}
-					options={formatOptions(visualOptions.border_radius)}
-					onChange={(val) => updateFormState('border_radius', val as SettingsFormData['border_radius'])}
-				/>
-				<input type="hidden" name="petitioner_border_radius" value={formState?.border_radius || ''} />
-			</div>
-
-			<div className="ptr-field-panel">
-				<SelectControl
-					label={__('Form Font Size', 'petitioner')}
-					value={formState?.base_font_size || ''}
-					options={formatOptions(visualOptions.base_font_size)}
-					onChange={(val) => updateFormState('base_font_size', val as SettingsFormData['base_font_size'])}
-				/>
-				<input type="hidden" name="petitioner_base_font_size" value={formState?.base_font_size || ''} />
-			</div>
-
-			<div className="ptr-field-panel">
-				<SelectControl
-					label={__('Button Font Size', 'petitioner')}
-					value={formState?.button_font_size || ''}
-					options={formatOptions(visualOptions.button_font_size)}
-					onChange={(val) => updateFormState('button_font_size', val as SettingsFormData['button_font_size'])}
-				/>
-				<input type="hidden" name="petitioner_button_font_size" value={formState?.button_font_size || ''} />
-			</div>
-
-			<div className="ptr-field-panel">
-				<SelectControl
-					label={__('Input Border Thickness', 'petitioner')}
-					value={formState?.input_border_width || ''}
-					options={formatOptions(visualOptions.input_border_width)}
-					onChange={(val) => updateFormState('input_border_width', val as SettingsFormData['input_border_width'])}
-				/>
-				<input type="hidden" name="petitioner_input_border_width" value={formState?.input_border_width || ''} />
-			</div>
-
-			<div className="ptr-field-panel">
-				<SelectControl
-					label={__('Field Spacing', 'petitioner')}
-					value={formState?.field_spacing || ''}
-					options={formatOptions(visualOptions.field_spacing)}
-					onChange={(val) => updateFormState('field_spacing', val as SettingsFormData['field_spacing'])}
-				/>
-				<input type="hidden" name="petitioner_field_spacing" value={formState?.field_spacing || ''} />
-			</div>
-
-			<div className="ptr-field-panel">
-				<SelectControl
-					label={__('Input Size', 'petitioner')}
-					value={formState?.input_size || ''}
-					options={formatOptions(visualOptions.input_size)}
-					onChange={(val) => updateFormState('input_size', val as SettingsFormData['input_size'])}
-				/>
-				<input type="hidden" name="petitioner_input_size" value={formState?.input_size || ''} />
-			</div>
-
-			<CodeEditor
-				code={formState?.custom_css || ''}
-				title={__('Custom CSS', 'petitioner')}
-				help={__('Add your custom CSS here.', 'petitioner')}
-				onChange={(val) => updateFormState('custom_css', val)}
-				isActive={isActive}
-			/>
 			</MainContent>
 			<SidebarContent>
 				<FormPreview />

--- a/src/js/admin/sections/SettingsFields/VisualSettings.tsx
+++ b/src/js/admin/sections/SettingsFields/VisualSettings.tsx
@@ -1,11 +1,12 @@
 import CodeEditor from '@admin/components/CodeEditor';
 import ColorField from '@admin/components/ColorField';
 import { useSettingsFormContext } from '@admin/context/SettingsContext';
+import { SelectControl } from '@wordpress/components';
 
 export default function VisualSettings() {
 	const { formState, updateFormState, windowPetitionerData } = useSettingsFormContext();
-	
-	const defaultColors = windowPetitionerData.default_values.colors || {
+
+	const defaultColors = windowPetitionerData?.default_values?.colors || {
 		primary: '#000',
 		dark: '#000',
 		grey: '#000',
@@ -102,6 +103,106 @@ export default function VisualSettings() {
 						updateFormState('grey_color', newColor)
 					}
 				/>
+			</div>
+
+			<hr />
+
+			<h3 style={{ marginBottom: '10px' }}>Layout & Sizing</h3>
+			<div className="ptr-field-panel">
+				<SelectControl
+					label="Border Radius"
+					value={formState?.border_radius || ''}
+					options={[
+						{ label: 'Default (8px)', value: '' },
+						{ label: 'Sharp (2px)', value: 'xs' },
+						{ label: 'Slightly Rounded (4px)', value: 'sm' },
+						{ label: 'Rounded (8px)', value: 'md' },
+						{ label: 'Very Rounded (16px)', value: 'lg' },
+						{ label: 'Pill (999px)', value: 'full' },
+					]}
+					onChange={(val) => updateFormState('border_radius', val)}
+				/>
+				<input type="hidden" name="petitioner_border_radius" value={formState?.border_radius || ''} />
+			</div>
+
+			<div className="ptr-field-panel">
+				<SelectControl
+					label="Form Font Size"
+					value={formState?.base_font_size || ''}
+					options={[
+						{ label: 'Default (14px)', value: '' },
+						{ label: 'Extra Small (12px)', value: 'xs' },
+						{ label: 'Small (14px)', value: 'sm' },
+						{ label: 'Medium (16px)', value: 'md' },
+					]}
+					onChange={(val) => updateFormState('base_font_size', val)}
+				/>
+				<input type="hidden" name="petitioner_base_font_size" value={formState?.base_font_size || ''} />
+			</div>
+
+			<div className="ptr-field-panel">
+				<SelectControl
+					label="Button Font Size"
+					value={formState?.button_font_size || ''}
+					options={[
+						{ label: 'Default (18px)', value: '' },
+						{ label: 'Extra Small (12px)', value: 'xs' },
+						{ label: 'Small (14px)', value: 'sm' },
+						{ label: 'Medium (16px)', value: 'md' },
+						{ label: 'Large (18px)', value: 'lg' },
+					]}
+					onChange={(val) => updateFormState('button_font_size', val)}
+				/>
+				<input type="hidden" name="petitioner_button_font_size" value={formState?.button_font_size || ''} />
+			</div>
+
+			<div className="ptr-field-panel">
+				<SelectControl
+					label="Input Border Thickness"
+					value={formState?.input_border_width || ''}
+					options={[
+						{ label: 'Default', value: '' },
+						{ label: '0px (None)', value: '0px' },
+						{ label: '1px', value: '1px' },
+						{ label: '2px', value: '2px' },
+						{ label: '3px', value: '3px' },
+					]}
+					onChange={(val) => updateFormState('input_border_width', val)}
+				/>
+				<input type="hidden" name="petitioner_input_border_width" value={formState?.input_border_width || ''} />
+			</div>
+
+			<div className="ptr-field-panel">
+				<SelectControl
+					label="Field Spacing"
+					value={formState?.field_spacing || ''}
+					options={[
+						{ label: 'Default (8px)', value: '' },
+						{ label: 'Extra Small (4px)', value: 'xs' },
+						{ label: 'Small (8px)', value: 'sm' },
+						{ label: 'Medium (16px)', value: 'md' },
+						{ label: 'Large (24px)', value: 'lg' },
+						{ label: 'Extra Large (32px)', value: 'xl' },
+					]}
+					onChange={(val) => updateFormState('field_spacing', val)}
+				/>
+				<input type="hidden" name="petitioner_field_spacing" value={formState?.field_spacing || ''} />
+			</div>
+
+			<div className="ptr-field-panel">
+				<SelectControl
+					label="Input Size"
+					value={formState?.input_size || ''}
+					options={[
+						{ label: 'Default (~62px)', value: '' },
+						{ label: 'Small (32px)', value: 'sm' },
+						{ label: 'Regular (40px)', value: 'md' },
+						{ label: 'Large (48px)', value: 'lg' },
+						{ label: 'Extra Large (~62px)', value: 'xl' },
+					]}
+					onChange={(val) => updateFormState('input_size', val)}
+				/>
+				<input type="hidden" name="petitioner_input_size" value={formState?.input_size || ''} />
 			</div>
 
 			<CodeEditor

--- a/src/js/admin/sections/SettingsFields/VisualSettings.tsx
+++ b/src/js/admin/sections/SettingsFields/VisualSettings.tsx
@@ -3,6 +3,7 @@ import ColorField from '@admin/components/ColorField';
 import { useSettingsFormContext } from '@admin/context/SettingsContext';
 import { SelectControl } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
+import type { SettingsFormData } from './consts';
 
 export default function VisualSettings() {
 	const { formState, updateFormState, windowPetitionerData } = useSettingsFormContext();
@@ -123,7 +124,7 @@ export default function VisualSettings() {
 					label={__('Border Radius', 'petitioner')}
 					value={formState?.border_radius || ''}
 					options={formatOptions(visualOptions.border_radius)}
-					onChange={(val) => updateFormState('border_radius', val)}
+					onChange={(val) => updateFormState('border_radius', val as SettingsFormData['border_radius'])}
 				/>
 				<input type="hidden" name="petitioner_border_radius" value={formState?.border_radius || ''} />
 			</div>
@@ -133,7 +134,7 @@ export default function VisualSettings() {
 					label={__('Form Font Size', 'petitioner')}
 					value={formState?.base_font_size || ''}
 					options={formatOptions(visualOptions.base_font_size)}
-					onChange={(val) => updateFormState('base_font_size', val)}
+					onChange={(val) => updateFormState('base_font_size', val as SettingsFormData['base_font_size'])}
 				/>
 				<input type="hidden" name="petitioner_base_font_size" value={formState?.base_font_size || ''} />
 			</div>
@@ -143,7 +144,7 @@ export default function VisualSettings() {
 					label={__('Button Font Size', 'petitioner')}
 					value={formState?.button_font_size || ''}
 					options={formatOptions(visualOptions.button_font_size)}
-					onChange={(val) => updateFormState('button_font_size', val)}
+					onChange={(val) => updateFormState('button_font_size', val as SettingsFormData['button_font_size'])}
 				/>
 				<input type="hidden" name="petitioner_button_font_size" value={formState?.button_font_size || ''} />
 			</div>
@@ -153,7 +154,7 @@ export default function VisualSettings() {
 					label={__('Input Border Thickness', 'petitioner')}
 					value={formState?.input_border_width || ''}
 					options={formatOptions(visualOptions.input_border_width)}
-					onChange={(val) => updateFormState('input_border_width', val)}
+					onChange={(val) => updateFormState('input_border_width', val as SettingsFormData['input_border_width'])}
 				/>
 				<input type="hidden" name="petitioner_input_border_width" value={formState?.input_border_width || ''} />
 			</div>
@@ -163,7 +164,7 @@ export default function VisualSettings() {
 					label={__('Field Spacing', 'petitioner')}
 					value={formState?.field_spacing || ''}
 					options={formatOptions(visualOptions.field_spacing)}
-					onChange={(val) => updateFormState('field_spacing', val)}
+					onChange={(val) => updateFormState('field_spacing', val as SettingsFormData['field_spacing'])}
 				/>
 				<input type="hidden" name="petitioner_field_spacing" value={formState?.field_spacing || ''} />
 			</div>
@@ -173,7 +174,7 @@ export default function VisualSettings() {
 					label={__('Input Size', 'petitioner')}
 					value={formState?.input_size || ''}
 					options={formatOptions(visualOptions.input_size)}
-					onChange={(val) => updateFormState('input_size', val)}
+					onChange={(val) => updateFormState('input_size', val as SettingsFormData['input_size'])}
 				/>
 				<input type="hidden" name="petitioner_input_size" value={formState?.input_size || ''} />
 			</div>

--- a/src/js/admin/sections/SettingsFields/VisualSettings.tsx
+++ b/src/js/admin/sections/SettingsFields/VisualSettings.tsx
@@ -13,6 +13,15 @@ export default function VisualSettings() {
 		grey: '#000',
 	};
 
+	const visualOptions = windowPetitionerData?.default_values?.visual_options || {};
+	
+	const formatOptions = (optionsObj: Record<string, string> = {}) => {
+		return Object.entries(optionsObj).map(([value, label]) => ({
+			label,
+			value,
+		}));
+	};
+
 	return (
 		<>
 			<p>
@@ -113,14 +122,7 @@ export default function VisualSettings() {
 				<SelectControl
 					label={__('Border Radius', 'petitioner')}
 					value={formState?.border_radius || ''}
-					options={[
-						{ label: __('Default (8px)', 'petitioner'), value: '' },
-						{ label: __('Sharp (2px)', 'petitioner'), value: 'xs' },
-						{ label: __('Slightly Rounded (4px)', 'petitioner'), value: 'sm' },
-						{ label: __('Rounded (8px)', 'petitioner'), value: 'md' },
-						{ label: __('Very Rounded (16px)', 'petitioner'), value: 'lg' },
-						{ label: __('Pill (999px)', 'petitioner'), value: 'full' },
-					]}
+					options={formatOptions(visualOptions.border_radius)}
 					onChange={(val) => updateFormState('border_radius', val)}
 				/>
 				<input type="hidden" name="petitioner_border_radius" value={formState?.border_radius || ''} />
@@ -130,12 +132,7 @@ export default function VisualSettings() {
 				<SelectControl
 					label={__('Form Font Size', 'petitioner')}
 					value={formState?.base_font_size || ''}
-					options={[
-						{ label: __('Default (14px)', 'petitioner'), value: '' },
-						{ label: __('Extra Small (12px)', 'petitioner'), value: 'xs' },
-						{ label: __('Small (14px)', 'petitioner'), value: 'sm' },
-						{ label: __('Medium (16px)', 'petitioner'), value: 'md' },
-					]}
+					options={formatOptions(visualOptions.base_font_size)}
 					onChange={(val) => updateFormState('base_font_size', val)}
 				/>
 				<input type="hidden" name="petitioner_base_font_size" value={formState?.base_font_size || ''} />
@@ -145,13 +142,7 @@ export default function VisualSettings() {
 				<SelectControl
 					label={__('Button Font Size', 'petitioner')}
 					value={formState?.button_font_size || ''}
-					options={[
-						{ label: __('Default (18px)', 'petitioner'), value: '' },
-						{ label: __('Extra Small (12px)', 'petitioner'), value: 'xs' },
-						{ label: __('Small (14px)', 'petitioner'), value: 'sm' },
-						{ label: __('Medium (16px)', 'petitioner'), value: 'md' },
-						{ label: __('Large (18px)', 'petitioner'), value: 'lg' },
-					]}
+					options={formatOptions(visualOptions.button_font_size)}
 					onChange={(val) => updateFormState('button_font_size', val)}
 				/>
 				<input type="hidden" name="petitioner_button_font_size" value={formState?.button_font_size || ''} />
@@ -161,13 +152,7 @@ export default function VisualSettings() {
 				<SelectControl
 					label={__('Input Border Thickness', 'petitioner')}
 					value={formState?.input_border_width || ''}
-					options={[
-						{ label: __('Default', 'petitioner'), value: '' },
-						{ label: __('0px (None)', 'petitioner'), value: '0px' },
-						{ label: __('1px', 'petitioner'), value: '1px' },
-						{ label: __('2px', 'petitioner'), value: '2px' },
-						{ label: __('3px', 'petitioner'), value: '3px' },
-					]}
+					options={formatOptions(visualOptions.input_border_width)}
 					onChange={(val) => updateFormState('input_border_width', val)}
 				/>
 				<input type="hidden" name="petitioner_input_border_width" value={formState?.input_border_width || ''} />
@@ -177,14 +162,7 @@ export default function VisualSettings() {
 				<SelectControl
 					label={__('Field Spacing', 'petitioner')}
 					value={formState?.field_spacing || ''}
-					options={[
-						{ label: __('Default (8px)', 'petitioner'), value: '' },
-						{ label: __('Extra Small (4px)', 'petitioner'), value: 'xs' },
-						{ label: __('Small (8px)', 'petitioner'), value: 'sm' },
-						{ label: __('Medium (16px)', 'petitioner'), value: 'md' },
-						{ label: __('Large (24px)', 'petitioner'), value: 'lg' },
-						{ label: __('Extra Large (32px)', 'petitioner'), value: 'xl' },
-					]}
+					options={formatOptions(visualOptions.field_spacing)}
 					onChange={(val) => updateFormState('field_spacing', val)}
 				/>
 				<input type="hidden" name="petitioner_field_spacing" value={formState?.field_spacing || ''} />
@@ -194,13 +172,7 @@ export default function VisualSettings() {
 				<SelectControl
 					label={__('Input Size', 'petitioner')}
 					value={formState?.input_size || ''}
-					options={[
-						{ label: __('Default (~62px)', 'petitioner'), value: '' },
-						{ label: __('Small (32px)', 'petitioner'), value: 'sm' },
-						{ label: __('Regular (40px)', 'petitioner'), value: 'md' },
-						{ label: __('Large (48px)', 'petitioner'), value: 'lg' },
-						{ label: __('Extra Large (~62px)', 'petitioner'), value: 'xl' },
-					]}
+					options={formatOptions(visualOptions.input_size)}
 					onChange={(val) => updateFormState('input_size', val)}
 				/>
 				<input type="hidden" name="petitioner_input_size" value={formState?.input_size || ''} />

--- a/src/js/admin/sections/SettingsFields/VisualSettings.tsx
+++ b/src/js/admin/sections/SettingsFields/VisualSettings.tsx
@@ -4,6 +4,8 @@ import { useSettingsFormContext } from '@admin/context/SettingsContext';
 import { SelectControl } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import type { SettingsFormData } from './consts';
+import { VisualSettingsLayout, MainContent, SidebarContent } from './styled';
+import FormPreview from './FormPreview';
 
 export default function VisualSettings() {
 	const { formState, updateFormState, windowPetitionerData } = useSettingsFormContext();
@@ -24,7 +26,8 @@ export default function VisualSettings() {
 	};
 
 	return (
-		<>
+		<VisualSettingsLayout>
+			<MainContent>
 			<p>
 				<input
 					checked={formState.show_letter}
@@ -184,6 +187,10 @@ export default function VisualSettings() {
 				title={__('Custom CSS', 'petitioner')}
 				help={__('Add your custom CSS here.', 'petitioner')}
 			/>
-		</>
+			</MainContent>
+			<SidebarContent>
+				<FormPreview />
+			</SidebarContent>
+		</VisualSettingsLayout>
 	);
 }

--- a/src/js/admin/sections/SettingsFields/VisualSettings.tsx
+++ b/src/js/admin/sections/SettingsFields/VisualSettings.tsx
@@ -186,6 +186,7 @@ export default function VisualSettings() {
 				code={formState?.custom_css || ''}
 				title={__('Custom CSS', 'petitioner')}
 				help={__('Add your custom CSS here.', 'petitioner')}
+				onChange={(val) => updateFormState('custom_css', val)}
 			/>
 			</MainContent>
 			<SidebarContent>

--- a/src/js/admin/sections/SettingsFields/VisualSettings.tsx
+++ b/src/js/admin/sections/SettingsFields/VisualSettings.tsx
@@ -7,7 +7,7 @@ import type { SettingsFormData } from './consts';
 import { VisualSettingsLayout, MainContent, SidebarContent } from './styled';
 import FormPreview from './FormPreview';
 
-export default function VisualSettings() {
+export default function VisualSettings({ isActive }: { isActive?: boolean }) {
 	const { formState, updateFormState, windowPetitionerData } = useSettingsFormContext();
 
 	const defaultColors = windowPetitionerData?.default_values?.colors || {
@@ -187,6 +187,7 @@ export default function VisualSettings() {
 				title={__('Custom CSS', 'petitioner')}
 				help={__('Add your custom CSS here.', 'petitioner')}
 				onChange={(val) => updateFormState('custom_css', val)}
+				isActive={isActive}
 			/>
 			</MainContent>
 			<SidebarContent>

--- a/src/js/admin/sections/SettingsFields/consts.ts
+++ b/src/js/admin/sections/SettingsFields/consts.ts
@@ -41,6 +41,7 @@ export type DefaultValues = {
 export interface WindowSettingsData extends SettingsFormData {
 	default_values?: DefaultValues;
 	preview_nonce?: string;
+	home_url: string;
 }
 
 export type SettingsFormContextValue = {

--- a/src/js/admin/sections/SettingsFields/consts.ts
+++ b/src/js/admin/sections/SettingsFields/consts.ts
@@ -40,6 +40,7 @@ export type DefaultValues = {
 
 export interface WindowSettingsData extends SettingsFormData {
 	default_values?: DefaultValues;
+	preview_nonce?: string;
 }
 
 export type SettingsFormContextValue = {

--- a/src/js/admin/sections/SettingsFields/consts.ts
+++ b/src/js/admin/sections/SettingsFields/consts.ts
@@ -1,3 +1,5 @@
+export type TShirtSize = '' | 'xs' | 'sm' | 'md' | 'lg' | 'xl' | 'full';
+
 export interface SettingsFormData {
 	show_letter: boolean;
 	show_title: boolean;
@@ -18,6 +20,12 @@ export interface SettingsFormData {
 	enable_akismet: boolean;
 	label_overrides: Record<string, string>;
 	active_tab?: string;
+	border_radius: Exclude<TShirtSize, 'xl'>;
+	base_font_size: Extract<TShirtSize, '' | 'xs' | 'sm' | 'md'>;
+	button_font_size: Extract<TShirtSize, '' | 'xs' | 'sm' | 'md' | 'lg'>;
+	field_spacing: Extract<TShirtSize, '' | 'xs' | 'sm' | 'md' | 'lg' | 'xl'>;
+	input_border_width: '' | '0px' | '1px' | '2px' | '3px';
+	input_size: Extract<TShirtSize, '' | 'sm' | 'md' | 'lg' | 'xl'>;
 }
 
 export type DefaultValues = {

--- a/src/js/admin/sections/SettingsFields/consts.ts
+++ b/src/js/admin/sections/SettingsFields/consts.ts
@@ -35,6 +35,7 @@ export type DefaultValues = {
 		grey: string;
 	};
 	labels: Record<string, string>;
+	visual_options?: Record<string, Record<string, string>>;
 };
 
 export interface WindowSettingsData extends SettingsFormData {

--- a/src/js/admin/sections/SettingsFields/consts.ts
+++ b/src/js/admin/sections/SettingsFields/consts.ts
@@ -40,7 +40,7 @@ export type DefaultValues = {
 
 export interface WindowSettingsData extends SettingsFormData {
 	default_values?: DefaultValues;
-	preview_nonce?: string;
+	preview_nonce: string;
 	home_url: string;
 }
 

--- a/src/js/admin/sections/SettingsFields/index.tsx
+++ b/src/js/admin/sections/SettingsFields/index.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useRef } from '@wordpress/element';
 import { Dashicon } from '@wordpress/components';
 import Tabs from '@admin/components/Tabs';
 import VisualSettings from './VisualSettings';
@@ -48,10 +49,47 @@ const tabs = [
 function SettingsFieldsComponent() {
 	const { formState } = useSettingsFormContext();
 	const { active_tab } = formState;
+	const iframeRef = useRef<HTMLIFrameElement>(null);
+
+	// Sync settings to the iframe via postMessage
+	useEffect(() => {
+		if (iframeRef.current && iframeRef.current.contentWindow) {
+			iframeRef.current.contentWindow.postMessage(
+				{ type: 'UPDATE_SETTINGS', payload: formState },
+				'*'
+			);
+		}
+	}, [formState]);
+
+	const previewUrl = `${ajaxurl}?action=petitioner_live_preview`;
 
 	return (
-		<div className="petitioner-settings-box">
-			<Tabs tabs={tabs} updateURL={true} defaultTab={active_tab} />
+		<div className="petitioner-settings-box" style={{ display: 'flex', gap: '20px', alignItems: 'flex-start' }}>
+			<div style={{ flex: '1 1 60%', maxWidth: '800px' }}>
+				<Tabs tabs={tabs} updateURL={true} defaultTab={active_tab} />
+			</div>
+			
+			<div style={{ flex: '1 1 40%', minWidth: '400px', position: 'sticky', top: '40px' }}>
+				<div style={{ border: '1px solid #ddd', borderRadius: '4px', background: '#fff', overflow: 'hidden', boxShadow: '0 1px 3px rgba(0,0,0,0.05)' }}>
+					<div style={{ padding: '10px 15px', background: '#f6f7f7', borderBottom: '1px solid #ddd', fontWeight: 600 }}>
+						{__('Live Preview', 'petitioner')}
+					</div>
+					<iframe 
+						ref={iframeRef}
+						src={previewUrl} 
+						style={{ width: '100%', height: '700px', border: 'none', display: 'block' }}
+						onLoad={() => {
+							// Trigger initial sync once iframe loads
+							if (iframeRef.current?.contentWindow) {
+								iframeRef.current.contentWindow.postMessage(
+									{ type: 'UPDATE_SETTINGS', payload: formState },
+									'*'
+								);
+							}
+						}}
+					/>
+				</div>
+			</div>
 		</div>
 	);
 }

--- a/src/js/admin/sections/SettingsFields/index.tsx
+++ b/src/js/admin/sections/SettingsFields/index.tsx
@@ -1,4 +1,3 @@
-import { useEffect, useRef } from '@wordpress/element';
 import { Dashicon } from '@wordpress/components';
 import Tabs from '@admin/components/Tabs';
 import VisualSettings from './VisualSettings';
@@ -9,6 +8,7 @@ import {
 	useSettingsFormContext,
 } from '@admin/context/SettingsContext';
 import { __ } from '@wordpress/i18n';
+import { SettingsContainer } from './styled';
 
 const tabs = [
 	{
@@ -49,48 +49,11 @@ const tabs = [
 function SettingsFieldsComponent() {
 	const { formState } = useSettingsFormContext();
 	const { active_tab } = formState;
-	const iframeRef = useRef<HTMLIFrameElement>(null);
-
-	// Sync settings to the iframe via postMessage
-	useEffect(() => {
-		if (iframeRef.current && iframeRef.current.contentWindow) {
-			iframeRef.current.contentWindow.postMessage(
-				{ type: 'UPDATE_SETTINGS', payload: formState },
-				'*'
-			);
-		}
-	}, [formState]);
-
-	const previewUrl = `${ajaxurl}?action=petitioner_live_preview`;
 
 	return (
-		<div className="petitioner-settings-box" style={{ display: 'flex', gap: '20px', alignItems: 'flex-start' }}>
-			<div style={{ flex: '1 1 60%', maxWidth: '800px' }}>
-				<Tabs tabs={tabs} updateURL={true} defaultTab={active_tab} />
-			</div>
-			
-			<div style={{ flex: '1 1 40%', minWidth: '400px', position: 'sticky', top: '40px' }}>
-				<div style={{ border: '1px solid #ddd', borderRadius: '4px', background: '#fff', overflow: 'hidden', boxShadow: '0 1px 3px rgba(0,0,0,0.05)' }}>
-					<div style={{ padding: '10px 15px', background: '#f6f7f7', borderBottom: '1px solid #ddd', fontWeight: 600 }}>
-						{__('Live Preview', 'petitioner')}
-					</div>
-					<iframe 
-						ref={iframeRef}
-						src={previewUrl} 
-						style={{ width: '100%', height: '700px', border: 'none', display: 'block' }}
-						onLoad={() => {
-							// Trigger initial sync once iframe loads
-							if (iframeRef.current?.contentWindow) {
-								iframeRef.current.contentWindow.postMessage(
-									{ type: 'UPDATE_SETTINGS', payload: formState },
-									'*'
-								);
-							}
-						}}
-					/>
-				</div>
-			</div>
-		</div>
+		<SettingsContainer>
+			<Tabs tabs={tabs} updateURL={true} defaultTab={active_tab} />
+		</SettingsContainer>
 	);
 }
 

--- a/src/js/admin/sections/SettingsFields/styled.tsx
+++ b/src/js/admin/sections/SettingsFields/styled.tsx
@@ -42,3 +42,13 @@ export const SizingGrid = styled.div`
 		flex-grow: 1;
 	}
 `
+
+export const SecurityWarning = styled.p`
+	color: #d63638;
+	margin-top: 4px;
+	font-size: 13px;
+
+	strong {
+		font-weight: 600;
+	}
+`

--- a/src/js/admin/sections/SettingsFields/styled.tsx
+++ b/src/js/admin/sections/SettingsFields/styled.tsx
@@ -1,4 +1,5 @@
 import styled from 'styled-components';
+import { SPACINGS, BREAKPOINTS } from '@admin/theme';
 
 export const SettingsContainer = styled.div.attrs({ className: 'petitioner-settings-box' })``;
 
@@ -19,3 +20,14 @@ export const SidebarContent = styled.div`
 	position: sticky;
 	top: 40px;
 `;
+
+export const SizingGrid = styled.div`
+	display: grid;
+	gap: ${SPACINGS.lg};
+	grid-template-columns: 1fr;
+	grid-auto-rows: min-content;
+
+	@media (min-width: ${BREAKPOINTS.xl}px) {
+		grid-template-columns: repeat(2, 250px);
+	}
+`

--- a/src/js/admin/sections/SettingsFields/styled.tsx
+++ b/src/js/admin/sections/SettingsFields/styled.tsx
@@ -10,24 +10,35 @@ export const VisualSettingsLayout = styled.div`
 `;
 
 export const MainContent = styled.div`
-	flex: 1 1 60%;
-	max-width: 800px;
+	@media (min-width: ${BREAKPOINTS.lg}px) {
+		flex: 1 1 60%;
+		max-width: 800px;
+	}
 `;
 
 export const SidebarContent = styled.div`
-	flex: 1 1 40%;
-	min-width: 400px;
-	position: sticky;
-	top: 40px;
+	display: none;
+
+	@media (min-width: ${BREAKPOINTS.xl}px) {
+		display: block;
+		flex: 1 1 40%;
+		min-width: 400px;
+		position: sticky;
+		top: 40px;
+	}
 `;
 
 export const SizingGrid = styled.div`
 	display: grid;
-	gap: ${SPACINGS.lg};
+	gap: ${SPACINGS['2xl']};
 	grid-template-columns: 1fr;
 	grid-auto-rows: min-content;
 
 	@media (min-width: ${BREAKPOINTS.xl}px) {
 		grid-template-columns: repeat(2, 250px);
+	}
+
+	.ptr-field-panel > * {
+		flex-grow: 1;
 	}
 `

--- a/src/js/admin/sections/SettingsFields/styled.tsx
+++ b/src/js/admin/sections/SettingsFields/styled.tsx
@@ -1,0 +1,21 @@
+import styled from 'styled-components';
+
+export const SettingsContainer = styled.div.attrs({ className: 'petitioner-settings-box' })``;
+
+export const VisualSettingsLayout = styled.div`
+	display: flex;
+	gap: 20px;
+	align-items: flex-start;
+`;
+
+export const MainContent = styled.div`
+	flex: 1 1 60%;
+	max-width: 800px;
+`;
+
+export const SidebarContent = styled.div`
+	flex: 1 1 40%;
+	min-width: 400px;
+	position: sticky;
+	top: 40px;
+`;

--- a/tests/js/admin/sections/SettingsFields/FormPreview/hooks.test.ts
+++ b/tests/js/admin/sections/SettingsFields/FormPreview/hooks.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useFormPreview } from '@admin/sections/SettingsFields/FormPreview/hooks';
+import { useSettingsFormContext } from '@admin/context/SettingsContext';
+import { fetchPreviewCSS, localSaveFormID, localGetSavedFormId } from '@admin/sections/SettingsFields/FormPreview/utilities';
+import { useSelect } from '@wordpress/data';
+
+// Map @wordpress/element to react for testing environments
+vi.mock('@wordpress/element', async () => {
+    return await vi.importActual('react');
+});
+
+vi.mock('@wordpress/data', () => ({
+    useSelect: vi.fn(),
+}));
+
+vi.mock('@admin/context/SettingsContext', () => ({
+    useSettingsFormContext: vi.fn(),
+}));
+
+vi.mock('@admin/sections/SettingsFields/FormPreview/utilities', () => ({
+    fetchPreviewCSS: vi.fn(),
+    localSaveFormID: vi.fn(),
+    localGetSavedFormId: vi.fn(),
+}));
+
+describe('useFormPreview hook', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+
+        // Default context
+        vi.mocked(useSettingsFormContext).mockReturnValue({
+            // @ts-ignore: its ok for mock
+            formState: { custom_css: 'body { color: blue; }' },
+            // @ts-ignore: its ok for mock
+            windowPetitionerData: {
+                home_url: 'https://frontend.com',
+                preview_nonce: 'abc123nonce',
+            },
+        });
+
+        // Default petitions
+        vi.mocked(useSelect).mockReturnValue([
+            { id: 99, title: { rendered: 'Save the Ocean' } }
+        ]);
+
+        // Default local storage mock
+        vi.mocked(localGetSavedFormId).mockReturnValue(0);
+
+        // Mock window location
+        Object.defineProperty(window, 'location', {
+            value: { href: 'https://backend.com/wp-admin/admin.php' },
+            writable: true
+        });
+    });
+
+    it('initializes and auto-selects the first petition if none saved', () => {
+        const { result } = renderHook(() => useFormPreview());
+
+        // It should auto-select ID 99 since localGetSavedFormId returned 0
+        expect(result.current.selectedFormId).toBe(99);
+        expect(result.current.previewUrl).toBe('https://frontend.com?petitioner_live_preview=1&form_id=99');
+    });
+
+    it('initializes with the saved form ID if it exists', () => {
+        vi.mocked(localGetSavedFormId).mockReturnValue(42);
+
+        const { result } = renderHook(() => useFormPreview());
+
+        expect(result.current.selectedFormId).toBe(42);
+        expect(result.current.previewUrl).toBe('https://frontend.com?petitioner_live_preview=1&form_id=42');
+    });
+
+    it('syncPreview posts visibility data securely to the correct origin', async () => {
+        const { result } = renderHook(() => useFormPreview());
+
+        // Mock the iframe contentWindow
+        const postMessageMock = vi.fn();
+        // @ts-ignore: Intentionally assigning to readonly 'current' property to mock the iframe ref for testing
+        result.current.iframeRef.current = {
+            contentWindow: { postMessage: postMessageMock }
+        };
+
+        act(() => {
+            result.current.syncPreview();
+        });
+
+        // Verifies the target origin is strictly extracted from home_url (not window.location)
+        expect(postMessageMock).toHaveBeenCalledWith(
+            { type: 'UPDATE_VISIBILITY', payload: { custom_css: 'body { color: blue; }' } },
+            'https://frontend.com'
+        );
+
+        // Verifies CSS compilation is triggered
+        expect(fetchPreviewCSS).toHaveBeenCalledTimes(1);
+    });
+
+    it('onFormSelect updates state and triggers localSaveFormID', () => {
+        const { result } = renderHook(() => useFormPreview());
+
+        act(() => {
+            result.current.onFormSelect(123);
+        });
+
+        expect(result.current.selectedFormId).toBe(123);
+        expect(localSaveFormID).toHaveBeenCalledWith(123);
+    });
+});

--- a/tests/js/admin/sections/SettingsFields/FormPreview/index.test.tsx
+++ b/tests/js/admin/sections/SettingsFields/FormPreview/index.test.tsx
@@ -1,0 +1,94 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import FormPreview from '@admin/sections/SettingsFields/FormPreview';
+import { useFormPreview } from '@admin/sections/SettingsFields/FormPreview/hooks';
+
+// Mock the hook so we can control its state
+vi.mock('@admin/sections/SettingsFields/FormPreview/hooks', () => ({
+    useFormPreview: vi.fn(),
+}));
+
+// Mock wp i18n
+vi.mock('@wordpress/i18n', () => ({
+    __: (text: string) => text,
+}));
+
+// Mock wp html-entities
+vi.mock('@wordpress/html-entities', () => ({
+    decodeEntities: (text: string) => text,
+}));
+
+describe('FormPreview', () => {
+    const mockOnFormSelect = vi.fn();
+    const mockSetIframeLoaded = vi.fn();
+    const mockSyncPreview = vi.fn();
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+        
+        // Provide default successful return values for our hook
+        vi.mocked(useFormPreview).mockReturnValue({
+            iframeRef: { current: null },
+            previewUrl: 'https://getpetitioner.com/?petitioner_live_preview=1&form_id=1',
+            selectedFormId: 1,
+            petitions: [
+                { id: 1, title: { rendered: 'Protect Wildlife' } },
+                { id: 2, title: { rendered: 'Save the Parks' } }
+            ],
+            setIframeLoaded: mockSetIframeLoaded,
+            onFormSelect: mockOnFormSelect,
+            syncPreview: mockSyncPreview,
+        });
+    });
+
+    it('renders the header and the iframe correctly', () => {
+        const { container } = render(<FormPreview />);
+        
+        expect(screen.getByText('Live Preview')).toBeInTheDocument();
+        
+        const iframe = container.querySelector('iframe');
+        expect(iframe).toBeInTheDocument();
+        expect(iframe).toHaveAttribute('src', 'https://getpetitioner.com/?petitioner_live_preview=1&form_id=1');
+    });
+
+    it('renders the petition dropdown and options when petitions exist', () => {
+        render(<FormPreview />);
+        
+        const select = screen.getByRole('combobox');
+        expect(select).toBeInTheDocument();
+        expect(select).toHaveValue('1');
+
+        const options = screen.getAllByRole('option');
+        expect(options).toHaveLength(2);
+        expect(options[0]).toHaveTextContent('Protect Wildlife');
+        expect(options[1]).toHaveTextContent('Save the Parks');
+    });
+
+    it('calls onFormSelect when a different petition is chosen', () => {
+        render(<FormPreview />);
+        
+        const select = screen.getByRole('combobox');
+        fireEvent.change(select, { target: { value: '2' } });
+        
+        expect(mockOnFormSelect).toHaveBeenCalledTimes(1);
+        expect(mockOnFormSelect).toHaveBeenCalledWith(2);
+    });
+
+    it('does not render the dropdown if the petitions array is empty', () => {
+        // Override mock to return empty array
+        vi.mocked(useFormPreview).mockReturnValue({
+            iframeRef: { current: null },
+            previewUrl: 'https://getpetitioner.com/?petitioner_live_preview=1&form_id=0',
+            selectedFormId: 0,
+            petitions: [],
+            setIframeLoaded: mockSetIframeLoaded,
+            onFormSelect: mockOnFormSelect,
+            syncPreview: mockSyncPreview,
+        });
+
+        render(<FormPreview />);
+        
+        // Select shouldn't be there
+        expect(screen.queryByRole('combobox')).not.toBeInTheDocument();
+    });
+});

--- a/tests/js/admin/sections/SettingsFields/FormPreview/utilities.test.ts
+++ b/tests/js/admin/sections/SettingsFields/FormPreview/utilities.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { localGetSavedFormId, localSaveFormID } from '@admin/sections/SettingsFields/FormPreview/utilities';
+
+const LOCAL_STORAGE_KEY = 'petitioner_preview_form_id'; // We hardcode it here since it's not exported
+
+describe('FormPreview utilities', () => {
+    beforeEach(() => {
+        window.localStorage.clear();
+        vi.restoreAllMocks();
+    });
+
+    describe('localGetSavedFormId', () => {
+        it('returns null if local storage has "NaN"', () => {
+            window.localStorage.setItem(LOCAL_STORAGE_KEY, 'NaN');
+            expect(localGetSavedFormId()).toBeNull();
+        });
+
+        it('returns null if local storage has "undefined"', () => {
+            window.localStorage.setItem(LOCAL_STORAGE_KEY, 'undefined');
+            expect(localGetSavedFormId()).toBeNull();
+        });
+
+        it('returns the number correctly', () => {
+            window.localStorage.setItem(LOCAL_STORAGE_KEY, '42');
+            expect(localGetSavedFormId()).toBe(42);
+        });
+    });
+
+    describe('localSaveFormID', () => {
+        it('does not save NaN', () => {
+            localSaveFormID(NaN);
+            expect(window.localStorage.getItem(LOCAL_STORAGE_KEY)).toBeNull();
+        });
+
+        it('does not save zero or negative numbers', () => {
+            localSaveFormID(0);
+            localSaveFormID(-5);
+            expect(window.localStorage.getItem(LOCAL_STORAGE_KEY)).toBeNull();
+        });
+
+        it('saves positive numbers', () => {
+            localSaveFormID(42);
+            expect(window.localStorage.getItem(LOCAL_STORAGE_KEY)).toBe('42');
+        });
+    });
+});

--- a/tests/js/admin/sections/SettingsFields/FormPreview/utilities.test.ts
+++ b/tests/js/admin/sections/SettingsFields/FormPreview/utilities.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { localGetSavedFormId, localSaveFormID } from '@admin/sections/SettingsFields/FormPreview/utilities';
+import { LOCAL_STORAGE_KEY } from '@admin/sections/SettingsFields/FormPreview/consts';
 
-const LOCAL_STORAGE_KEY = 'petitioner_preview_form_id'; // We hardcode it here since it's not exported
 
 describe('FormPreview utilities', () => {
     beforeEach(() => {

--- a/tests/php/admin-ui/settings/test-class-admin-live-preview.php
+++ b/tests/php/admin-ui/settings/test-class-admin-live-preview.php
@@ -1,0 +1,19 @@
+<?php
+
+use WorDBless\BaseTestCase;
+
+class Test_Class_Admin_Live_Preview extends BaseTestCase
+{
+    public function test_render_preview_script_outputs_correct_origin_check()
+    {
+        ob_start();
+        AV_Petitioner_Admin_Live_Preview::render_preview_script();
+        $output = ob_get_clean();
+
+        // Verify that the script dynamically calculates the admin origin
+        $this->assertStringContainsString("const adminOrigin = new URL('", $output);
+        
+        // Verify that it enforces the strict check against the admin origin
+        $this->assertStringContainsString("if (event.origin !== adminOrigin) return;", $output);
+    }
+}

--- a/tests/php/admin-ui/settings/test-class-admin-live-preview.php
+++ b/tests/php/admin-ui/settings/test-class-admin-live-preview.php
@@ -11,7 +11,7 @@ class Test_Class_Admin_Live_Preview extends BaseTestCase
         $output = ob_get_clean();
 
         // Verify that the script dynamically calculates the admin origin
-        $this->assertStringContainsString("const adminOrigin = new URL('", $output);
+        $this->assertStringContainsString('const adminOrigin = new URL(' . wp_json_encode(admin_url()) . ', window.location.href).origin;', $output);
         
         // Verify that it enforces the strict check against the admin origin
         $this->assertStringContainsString("if (event.origin !== adminOrigin) return;", $output);

--- a/tests/php/frontend/test-class-dynamic-css.php
+++ b/tests/php/frontend/test-class-dynamic-css.php
@@ -1,0 +1,37 @@
+<?php
+
+use WorDBless\BaseTestCase;
+
+class Test_Class_Dynamic_CSS extends BaseTestCase
+{
+    public function tear_down()
+    {
+        parent::tear_down();
+        delete_option('petitioner_settings');
+        delete_option('petitioner_custom_css');
+    }
+
+    public function test_generate_css_uses_overrides()
+    {
+        // Provide an override array specifically for the live preview
+        $overrides = [
+            'custom_css' => 'body { color: hotpink; }'
+        ];
+        
+        $css = AV_Petitioner_Dynamic_CSS::generate_css($overrides);
+        
+        // Ensure the custom CSS override is present in the final output
+        $this->assertStringContainsString('body { color: hotpink; }', $css);
+    }
+
+    public function test_generate_css_falls_back_to_saved_options()
+    {
+        // Save to DB but don't pass as override
+        update_option('petitioner_custom_css', 'body { color: blue; }');
+        
+        $css = AV_Petitioner_Dynamic_CSS::generate_css([]);
+        
+        // Ensure it falls back to the database option
+        $this->assertStringContainsString('body { color: blue; }', $css);
+    }
+}

--- a/tests/php/test-class-setup.php
+++ b/tests/php/test-class-setup.php
@@ -1,0 +1,61 @@
+<?php
+
+use WorDBless\BaseTestCase;
+
+class Test_Class_Setup extends BaseTestCase
+{
+    public function set_up()
+    {
+        parent::set_up();
+        // Ensure wp_styles is initialized for the test environment
+        $GLOBALS['wp_styles'] = new WP_Styles();
+    }
+
+    public function tear_down()
+    {
+        parent::tear_down();
+        delete_option('petitioner_custom_css');
+    }
+
+    public function test_custom_css_sanitization_preserves_valid_chars()
+    {
+        // Provide valid CSS containing a < character
+        update_option('petitioner_custom_css', 'body { content: "<viewport>"; }');
+
+        $setup = new AV_Petitioner_Setup();
+        $setup->enqueue_frontend_assets();
+
+        global $wp_styles;
+        $inline_styles = $wp_styles->get_data('petitioner-style', 'after');
+
+        $this->assertIsArray($inline_styles, 'Inline styles should be enqueued as an array.');
+
+        $css_output = implode(' ', $inline_styles);
+
+        // Verify that the < character was NOT stripped
+        $this->assertStringContainsString('body { content: "<viewport>"; }', $css_output);
+    }
+
+    public function test_custom_css_sanitization_strips_style_tags()
+    {
+        // Provide malicious payload attempting to break out of the style tag
+        update_option('petitioner_custom_css', 'body { background: red; } </style><script>alert("xss")</script>');
+
+        $setup = new AV_Petitioner_Setup();
+        $setup->enqueue_frontend_assets();
+
+        global $wp_styles;
+        $inline_styles = $wp_styles->get_data('petitioner-style', 'after');
+
+        $this->assertIsArray($inline_styles, 'Inline styles should be enqueued as an array.');
+
+        $css_output = implode(' ', $inline_styles);
+
+        // Verify that the </style> tag was stripped completely
+        $this->assertStringNotContainsString('</style>', $css_output);
+        $this->assertStringNotContainsString('<style', $css_output);
+
+        // Verify that the rest of the payload was preserved (locked inside the CSS block)
+        $this->assertStringContainsString('body { background: red; } <script>alert("xss")</script>', $css_output);
+    }
+}

--- a/vite.admin.config.ts
+++ b/vite.admin.config.ts
@@ -11,6 +11,7 @@ const wpExternals = [
 	'@wordpress/element',
 	'@wordpress/hooks',
 	'@wordpress/i18n',
+	'@wordpress/html-entities',
 	'react',
 	'react-dom',
 ];
@@ -23,6 +24,7 @@ const wpGlobals: Record<string, string> = {
 	'@wordpress/element': 'wp.element',
 	'@wordpress/hooks': 'wp.hooks',
 	'@wordpress/i18n': 'wp.i18n',
+	'@wordpress/html-entities': 'wp.htmlEntities',
 	react: 'React',
 	'react-dom': 'ReactDOM',
 };


### PR DESCRIPTION
## Description of change

* Improvements
    * Additional spacing and font size controls in the styles customizer
    * A new visual preview in the customizer
    * Improved the `petitioner_submission_finalized` hook: it now hydrates the submission data that it sends. Good for working with the custom fields.

<img width="1274" height="786" alt="image" src="https://github.com/user-attachments/assets/fae5f462-750c-4f4d-9834-4f66a1106966" />
