### PR TITLE
Issue #114: live customizer preview

### DIFF
--- a/inc/admin-ui/settings/class-admin-live-preview.php
+++ b/inc/admin-ui/settings/class-admin-live-preview.php
@@ -56,7 +56,10 @@ class AV_Petitioner_Admin_Live_Preview
 
         check_ajax_referer(self::NONCE_ACTION, 'petitioner_nonce');
 
-        $payload = isset($_POST['payload']) ? (array) $_POST['payload'] : [];
+        $payload = isset($_POST['payload']) ? json_decode(wp_unslash($_POST['payload']), true) : [];
+        if (!is_array($payload)) {
+            $payload = [];
+        }
         
         // Pass payload as overrides to the dynamic CSS generator
         $css = AV_Petitioner_Dynamic_CSS::generate_css($payload);

--- a/inc/admin-ui/settings/class-admin-live-preview.php
+++ b/inc/admin-ui/settings/class-admin-live-preview.php
@@ -58,7 +58,7 @@ class AV_Petitioner_Admin_Live_Preview
         <head>
             <meta charset="<?php bloginfo('charset'); ?>">
             <meta name="viewport" content="width=device-width, initial-scale=1.0">
-            <title>Petitioner Live Preview</title>
+            <title><?php esc_html_e('Petitioner Live Preview', 'petitioner'); ?></title>
             <?php wp_head(); ?>
             <style>
                 body {

--- a/inc/admin-ui/settings/class-admin-live-preview.php
+++ b/inc/admin-ui/settings/class-admin-live-preview.php
@@ -1,0 +1,187 @@
+<?php
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+class AV_Petitioner_Admin_Live_Preview
+{
+    public static function init()
+    {
+        add_action('wp_ajax_petitioner_live_preview', [self::class, 'render_preview']);
+    }
+
+    public static function render_preview()
+    {
+        // Only allow admins
+        if (!current_user_can('manage_options')) {
+            wp_die('Unauthorized', 403);
+        }
+
+        $css_url = plugins_url('dist/main.css', AV_PETITIONER_PLUGIN_DIR . 'petitioner.php');
+        $css_path = AV_PETITIONER_PLUGIN_DIR . 'dist/main.css';
+        $css_ver = file_exists($css_path) ? filemtime($css_path) : AV_PETITIONER_PLUGIN_VERSION;
+        
+        // Generate the initial dynamic CSS based on saved settings
+        $initial_dynamic_css = '';
+        if (class_exists('AV_Petitioner_Dynamic_CSS')) {
+            $initial_dynamic_css = AV_Petitioner_Dynamic_CSS::generate_css();
+        }
+
+        ?>
+        <!DOCTYPE html>
+        <html lang="en">
+        <head>
+            <meta charset="UTF-8">
+            <meta name="viewport" content="width=device-width, initial-scale=1.0">
+            <title>Petitioner Live Preview</title>
+            <link rel="stylesheet" href="<?php echo esc_url($css_url); ?>?ver=<?php echo esc_attr($css_ver); ?>">
+            <style id="petitioner-dynamic-css">
+                <?php echo wp_strip_all_tags($initial_dynamic_css); ?>
+            </style>
+            <style>
+                body {
+                    background: transparent; 
+                    margin: 0;
+                    padding: 20px;
+                    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
+                }
+            </style>
+        </head>
+        <body>
+            <?php
+            $petitions = get_posts([
+                'post_type' => 'petitioner-petition',
+                'posts_per_page' => 1,
+                'post_status' => 'any'
+            ]);
+
+            if (!empty($petitions)) {
+                $frontend_ui = new AV_Petitioner_Frontend_UI();
+                echo $frontend_ui->display_form(['id' => $petitions[0]->ID]);
+            } else {
+                echo '<div class="petitioner"><div class="ptr-wrapper" style="padding: 20px; text-align: center;">';
+                echo '<p>' . esc_html__('Please create at least one petition to see the live preview.', 'petitioner') . '</p>';
+                echo '</div></div>';
+            }
+            ?>
+
+            <script>
+                // Listen for messages from the parent window
+                window.addEventListener('message', function(event) {
+                    if (event.data && event.data.type === 'UPDATE_SETTINGS') {
+                        const payload = event.data.payload;
+                        const root = document.querySelector('.petitioner');
+                        if (!root) return;
+                        
+                        // Toggle elements based on settings
+                        const titleEl = document.querySelector('.petitioner__title');
+                        if (titleEl) titleEl.style.display = payload.show_title ? 'block' : 'none';
+                        
+                        const letterEl = document.querySelector('.petitioner__btn--letter');
+                        if (letterEl) letterEl.style.display = payload.show_letter ? 'block' : 'none';
+
+                        const goalEl = document.querySelector('.petitioner__goal');
+                        if (goalEl) goalEl.style.display = payload.show_goal ? 'flex' : 'none';
+
+                        // Apply custom CSS
+                        let customStyleEl = document.getElementById('preview-custom-css');
+                        if (!customStyleEl) {
+                            customStyleEl = document.createElement('style');
+                            customStyleEl.id = 'preview-custom-css';
+                            document.head.appendChild(customStyleEl);
+                        }
+                        customStyleEl.textContent = payload.custom_css || '';
+
+                        const setVar = (name, val) => {
+                            if (val) {
+                                root.style.setProperty(name, val, 'important');
+                            } else {
+                                root.style.removeProperty(name);
+                            }
+                        };
+
+                        // Colors
+                        setVar('--ptr-color-primary', payload.primary_color);
+                        setVar('--ptr-color-dark', payload.dark_color);
+                        setVar('--ptr-color-grey', payload.grey_color);
+
+                        // Border Radius
+                        if (payload.border_radius) {
+                            setVar('--ptr-input-border-radius', `var(--ptr-border-radius-${payload.border_radius})`);
+                            setVar('--ptr-button-border-radius', `var(--ptr-border-radius-${payload.border_radius})`);
+                            
+                            let wrapperRadius = payload.border_radius === 'full' ? 'lg' : payload.border_radius;
+                            setVar('--ptr-wrapper-radius', `var(--ptr-border-radius-${wrapperRadius})`);
+                        } else {
+                            root.style.removeProperty('--ptr-input-border-radius');
+                            root.style.removeProperty('--ptr-button-border-radius');
+                            root.style.removeProperty('--ptr-wrapper-radius');
+                        }
+
+                        // Base Font Size
+                        if (payload.base_font_size) {
+                            setVar('--ptr-label-font-size', `var(--ptr-fs-${payload.base_font_size})`);
+                        } else {
+                            root.style.removeProperty('--ptr-label-font-size');
+                        }
+
+                        // Button Font Size
+                        if (payload.button_font_size) {
+                            setVar('--ptr-btn-font-size', `var(--ptr-fs-${payload.button_font_size})`);
+                        } else {
+                            root.style.removeProperty('--ptr-btn-font-size');
+                        }
+
+                        // Spacing
+                        if (payload.field_spacing) {
+                            setVar('--ptr-input-margin-bottom', `var(--ptr-spacer-${payload.field_spacing})`);
+                        } else {
+                            root.style.removeProperty('--ptr-input-margin-bottom');
+                        }
+
+                        // Border width
+                        if (payload.input_border_width) {
+                            setVar('--ptr-input-border-width', payload.input_border_width);
+                        } else {
+                            root.style.removeProperty('--ptr-input-border-width');
+                        }
+
+                        // Input Size
+                        if (payload.input_size) {
+                            switch(payload.input_size) {
+                                case 'sm':
+                                    setVar('--ptr-input-line-height', '24px');
+                                    setVar('--ptr-input-spacing-y', '4px');
+                                    setVar('--ptr-label-line-height', '1.4');
+                                    break;
+                                case 'md':
+                                    setVar('--ptr-input-line-height', '24px');
+                                    setVar('--ptr-input-spacing-y', '8px');
+                                    root.style.removeProperty('--ptr-label-line-height');
+                                    break;
+                                case 'lg':
+                                    setVar('--ptr-input-line-height', '32px');
+                                    setVar('--ptr-input-spacing-y', '8px');
+                                    root.style.removeProperty('--ptr-label-line-height');
+                                    break;
+                                case 'xl':
+                                    setVar('--ptr-input-line-height', '40px');
+                                    setVar('--ptr-input-spacing-y', '0.7rem');
+                                    root.style.removeProperty('--ptr-label-line-height');
+                                    break;
+                            }
+                        } else {
+                            root.style.removeProperty('--ptr-input-line-height');
+                            root.style.removeProperty('--ptr-input-spacing-y');
+                            root.style.removeProperty('--ptr-label-line-height');
+                        }
+                    }
+                });
+            </script>
+        </body>
+        </html>
+        <?php
+        wp_die();
+    }
+}

--- a/inc/admin-ui/settings/class-admin-live-preview.php
+++ b/inc/admin-ui/settings/class-admin-live-preview.php
@@ -8,187 +8,179 @@ class AV_Petitioner_Admin_Live_Preview
 {
     public static function init()
     {
-        add_action('wp_ajax_petitioner_live_preview', [self::class, 'render_preview']);
+        add_action('template_redirect', [self::class, 'render_preview']);
     }
 
     public static function render_preview()
     {
+        if (!isset($_GET['petitioner_live_preview'])) {
+            return;
+        }
+
         // Only allow admins
         if (!current_user_can('manage_options')) {
             wp_die('Unauthorized', 403);
         }
 
-        $css_url = plugins_url('dist/main.css', AV_PETITIONER_PLUGIN_DIR . 'petitioner.php');
-        $css_path = AV_PETITIONER_PLUGIN_DIR . 'dist/main.css';
-        $css_ver = file_exists($css_path) ? filemtime($css_path) : AV_PETITIONER_PLUGIN_VERSION;
+        $form_id = isset($_GET['form_id']) ? intval($_GET['form_id']) : 0;
         
-        // Generate the initial dynamic CSS based on saved settings
-        $initial_dynamic_css = '';
-        if (class_exists('AV_Petitioner_Dynamic_CSS')) {
-            $initial_dynamic_css = AV_Petitioner_Dynamic_CSS::generate_css();
-        }
+        // Remove admin bar for the preview
+        add_filter('show_admin_bar', '__return_false');
+        
+        // Add the postMessage listener script to the footer
+        add_action('wp_footer', [self::class, 'render_preview_script'], 999);
 
         ?>
         <!DOCTYPE html>
-        <html lang="en">
+        <html <?php language_attributes(); ?>>
         <head>
-            <meta charset="UTF-8">
+            <meta charset="<?php bloginfo('charset'); ?>">
             <meta name="viewport" content="width=device-width, initial-scale=1.0">
             <title>Petitioner Live Preview</title>
-            <link rel="stylesheet" href="<?php echo esc_url($css_url); ?>?ver=<?php echo esc_attr($css_ver); ?>">
-            <style id="petitioner-dynamic-css">
-                <?php echo wp_strip_all_tags($initial_dynamic_css); ?>
-            </style>
+            <?php wp_head(); ?>
             <style>
                 body {
                     background: transparent; 
                     margin: 0;
                     padding: 20px;
-                    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
                 }
+                html { margin-top: 0 !important; }
             </style>
         </head>
-        <body>
-            <?php
-            $form_id = isset($_GET['form_id']) ? intval($_GET['form_id']) : 0;
-            $petitions = [];
-
-            if ($form_id) {
-                $petitions = [get_post($form_id)];
-            } else {
-                $petitions = get_posts([
-                    'post_type' => 'petitioner-petition',
-                    'posts_per_page' => 1,
-                    'post_status' => 'any'
-                ]);
-            }
-
-            if (!empty($petitions) && $petitions[0]) {
-                $frontend_ui = new AV_Petitioner_Frontend_UI();
-                echo $frontend_ui->display_form(['id' => $petitions[0]->ID]);
-            } else {
-                echo '<div class="petitioner"><div class="ptr-wrapper" style="padding: 20px; text-align: center;">';
-                echo '<p>' . esc_html__('Please create at least one petition to see the live preview.', 'petitioner') . '</p>';
-                echo '</div></div>';
-            }
-            ?>
-
-            <script>
-                // Listen for messages from the parent window
-                window.addEventListener('message', function(event) {
-                    if (event.data && event.data.type === 'UPDATE_SETTINGS') {
-                        const payload = event.data.payload;
-                        const root = document.querySelector('.petitioner');
-                        if (!root) return;
-                        
-                        // Toggle elements based on settings
-                        const titleEl = document.querySelector('.petitioner__title');
-                        if (titleEl) titleEl.style.display = payload.show_title ? 'block' : 'none';
-                        
-                        const letterEl = document.querySelector('.petitioner__btn--letter');
-                        if (letterEl) letterEl.style.display = payload.show_letter ? 'block' : 'none';
-
-                        const goalEl = document.querySelector('.petitioner__goal');
-                        if (goalEl) goalEl.style.display = payload.show_goal ? 'flex' : 'none';
-
-                        // Apply custom CSS
-                        let customStyleEl = document.getElementById('preview-custom-css');
-                        if (!customStyleEl) {
-                            customStyleEl = document.createElement('style');
-                            customStyleEl.id = 'preview-custom-css';
-                            document.head.appendChild(customStyleEl);
-                        }
-                        customStyleEl.textContent = payload.custom_css || '';
-
-                        const setVar = (name, val) => {
-                            if (val) {
-                                root.style.setProperty(name, val, 'important');
-                            } else {
-                                root.style.removeProperty(name);
-                            }
-                        };
-
-                        // Colors
-                        setVar('--ptr-color-primary', payload.primary_color);
-                        setVar('--ptr-color-dark', payload.dark_color);
-                        setVar('--ptr-color-grey', payload.grey_color);
-
-                        // Border Radius
-                        if (payload.border_radius) {
-                            setVar('--ptr-input-border-radius', `var(--ptr-border-radius-${payload.border_radius})`);
-                            setVar('--ptr-button-border-radius', `var(--ptr-border-radius-${payload.border_radius})`);
-                            
-                            let wrapperRadius = payload.border_radius === 'full' ? 'lg' : payload.border_radius;
-                            setVar('--ptr-wrapper-radius', `var(--ptr-border-radius-${wrapperRadius})`);
-                        } else {
-                            root.style.removeProperty('--ptr-input-border-radius');
-                            root.style.removeProperty('--ptr-button-border-radius');
-                            root.style.removeProperty('--ptr-wrapper-radius');
-                        }
-
-                        // Base Font Size
-                        if (payload.base_font_size) {
-                            setVar('--ptr-label-font-size', `var(--ptr-fs-${payload.base_font_size})`);
-                        } else {
-                            root.style.removeProperty('--ptr-label-font-size');
-                        }
-
-                        // Button Font Size
-                        if (payload.button_font_size) {
-                            setVar('--ptr-btn-font-size', `var(--ptr-fs-${payload.button_font_size})`);
-                        } else {
-                            root.style.removeProperty('--ptr-btn-font-size');
-                        }
-
-                        // Spacing
-                        if (payload.field_spacing) {
-                            setVar('--ptr-input-margin-bottom', `var(--ptr-spacer-${payload.field_spacing})`);
-                        } else {
-                            root.style.removeProperty('--ptr-input-margin-bottom');
-                        }
-
-                        // Border width
-                        if (payload.input_border_width) {
-                            setVar('--ptr-input-border-width', payload.input_border_width);
-                        } else {
-                            root.style.removeProperty('--ptr-input-border-width');
-                        }
-
-                        // Input Size
-                        if (payload.input_size) {
-                            switch(payload.input_size) {
-                                case 'sm':
-                                    setVar('--ptr-input-line-height', '24px');
-                                    setVar('--ptr-input-spacing-y', '4px');
-                                    setVar('--ptr-label-line-height', '1.4');
-                                    break;
-                                case 'md':
-                                    setVar('--ptr-input-line-height', '24px');
-                                    setVar('--ptr-input-spacing-y', '8px');
-                                    root.style.removeProperty('--ptr-label-line-height');
-                                    break;
-                                case 'lg':
-                                    setVar('--ptr-input-line-height', '32px');
-                                    setVar('--ptr-input-spacing-y', '8px');
-                                    root.style.removeProperty('--ptr-label-line-height');
-                                    break;
-                                case 'xl':
-                                    setVar('--ptr-input-line-height', '40px');
-                                    setVar('--ptr-input-spacing-y', '0.7rem');
-                                    root.style.removeProperty('--ptr-label-line-height');
-                                    break;
-                            }
-                        } else {
-                            root.style.removeProperty('--ptr-input-line-height');
-                            root.style.removeProperty('--ptr-input-spacing-y');
-                            root.style.removeProperty('--ptr-label-line-height');
-                        }
-                    }
-                });
-            </script>
+        <body <?php body_class(); ?>>
+            <div class="petitioner-preview-wrapper petitioner-preview" style="max-width: 800px; margin: 40px auto; padding: 20px;">
+                <?php
+                if ($form_id) {
+                    $frontend_ui = new AV_Petitioner_Frontend_UI();
+                    echo $frontend_ui->display_form(['id' => $form_id]);
+                } else {
+                    echo '<p>' . esc_html__('Please create at least one petition to see the live preview.', 'petitioner') . '</p>';
+                }
+                ?>
+            </div>
+            <?php wp_footer(); ?>
         </body>
         </html>
         <?php
-        wp_die();
+        exit;
+    }
+
+    public static function render_preview_script()
+    {
+        ?>
+        <script>
+            // Listen for messages from the parent window
+            window.addEventListener('message', function(event) {
+                if (event.data && event.data.type === 'UPDATE_SETTINGS') {
+                    const payload = event.data.payload;
+                    const root = document.querySelector('.petitioner');
+                    if (!root) return;
+                    
+                    // Toggle elements based on settings
+                    const titleEl = document.querySelector('.petitioner__title');
+                    if (titleEl) titleEl.style.display = payload.show_title ? 'block' : 'none';
+                    
+                    const letterEl = document.querySelector('.petitioner__btn--letter');
+                    if (letterEl) letterEl.style.display = payload.show_letter ? 'block' : 'none';
+
+                    const goalEl = document.querySelector('.petitioner__goal');
+                    if (goalEl) goalEl.style.display = payload.show_goal ? 'flex' : 'none';
+
+                    // Apply custom CSS
+                    let customStyleEl = document.getElementById('preview-custom-css');
+                    if (!customStyleEl) {
+                        customStyleEl = document.createElement('style');
+                        customStyleEl.id = 'preview-custom-css';
+                        document.head.appendChild(customStyleEl);
+                    }
+                    customStyleEl.textContent = payload.custom_css || '';
+
+                    const setVar = (name, val) => {
+                        if (val) {
+                            root.style.setProperty(name, val, 'important');
+                        } else {
+                            root.style.removeProperty(name);
+                        }
+                    };
+
+                    // Colors
+                    setVar('--ptr-color-primary', payload.primary_color);
+                    setVar('--ptr-color-dark', payload.dark_color);
+                    setVar('--ptr-color-grey', payload.grey_color);
+
+                    // Border Radius
+                    if (payload.border_radius) {
+                        setVar('--ptr-input-border-radius', `var(--ptr-border-radius-${payload.border_radius})`);
+                        setVar('--ptr-button-border-radius', `var(--ptr-border-radius-${payload.border_radius})`);
+                        
+                        let wrapperRadius = payload.border_radius === 'full' ? 'lg' : payload.border_radius;
+                        setVar('--ptr-wrapper-radius', `var(--ptr-border-radius-${wrapperRadius})`);
+                    } else {
+                        root.style.removeProperty('--ptr-input-border-radius');
+                        root.style.removeProperty('--ptr-button-border-radius');
+                        root.style.removeProperty('--ptr-wrapper-radius');
+                    }
+
+                    // Base Font Size
+                    if (payload.base_font_size) {
+                        setVar('--ptr-label-font-size', `var(--ptr-fs-${payload.base_font_size})`);
+                    } else {
+                        root.style.removeProperty('--ptr-label-font-size');
+                    }
+
+                    // Button Font Size
+                    if (payload.button_font_size) {
+                        setVar('--ptr-btn-font-size', `var(--ptr-fs-${payload.button_font_size})`);
+                    } else {
+                        root.style.removeProperty('--ptr-btn-font-size');
+                    }
+
+                    // Spacing
+                    if (payload.field_spacing) {
+                        setVar('--ptr-input-margin-bottom', `var(--ptr-spacer-${payload.field_spacing})`);
+                    } else {
+                        root.style.removeProperty('--ptr-input-margin-bottom');
+                    }
+
+                    // Border width
+                    if (payload.input_border_width) {
+                        setVar('--ptr-input-border-width', payload.input_border_width);
+                    } else {
+                        root.style.removeProperty('--ptr-input-border-width');
+                    }
+
+                    // Input Size
+                    if (payload.input_size) {
+                        switch(payload.input_size) {
+                            case 'sm':
+                                setVar('--ptr-input-line-height', '24px');
+                                setVar('--ptr-input-spacing-y', '4px');
+                                setVar('--ptr-label-line-height', '1.4');
+                                break;
+                            case 'md':
+                                setVar('--ptr-input-line-height', '24px');
+                                setVar('--ptr-input-spacing-y', '8px');
+                                root.style.removeProperty('--ptr-label-line-height');
+                                break;
+                            case 'lg':
+                                setVar('--ptr-input-line-height', '32px');
+                                setVar('--ptr-input-spacing-y', '8px');
+                                root.style.removeProperty('--ptr-label-line-height');
+                                break;
+                            case 'xl':
+                                setVar('--ptr-input-line-height', '40px');
+                                setVar('--ptr-input-spacing-y', '0.7rem');
+                                root.style.removeProperty('--ptr-label-line-height');
+                                break;
+                        }
+                    } else {
+                        root.style.removeProperty('--ptr-input-line-height');
+                        root.style.removeProperty('--ptr-input-spacing-y');
+                        root.style.removeProperty('--ptr-label-line-height');
+                    }
+                }
+            });
+        </script>
+        <?php
     }
 }

--- a/inc/admin-ui/settings/class-admin-live-preview.php
+++ b/inc/admin-ui/settings/class-admin-live-preview.php
@@ -60,6 +60,11 @@ class AV_Petitioner_Admin_Live_Preview
         if (!is_array($payload)) {
             $payload = [];
         }
+
+        // Sanitize custom CSS to prevent XSS/HTML injection
+        if (isset($payload['custom_css'])) {
+            $payload['custom_css'] = wp_strip_all_tags($payload['custom_css']);
+        }
         
         // Pass payload as overrides to the dynamic CSS generator
         $css = AV_Petitioner_Dynamic_CSS::generate_css($payload);

--- a/inc/admin-ui/settings/class-admin-live-preview.php
+++ b/inc/admin-ui/settings/class-admin-live-preview.php
@@ -4,13 +4,35 @@ if (!defined('ABSPATH')) {
     exit;
 }
 
+/**
+ * Class AV_Petitioner_Admin_Live_Preview
+ * 
+ * Handles the rendering of the live preview iframe on the Visual Settings page.
+ * Uses a bare frontend template via `template_redirect` to ensure active theme 
+ * styles are loaded accurately.
+ *
+ * @since 0.8.5
+ */
 class AV_Petitioner_Admin_Live_Preview
 {
+    /**
+     * Initializes the class and hooks into WordPress.
+     *
+     * @since 0.8.5
+     * @return void
+     */
     public static function init()
     {
         add_action('template_redirect', [self::class, 'render_preview']);
     }
 
+    /**
+     * Renders the bare HTML shell for the live preview iframe.
+     * Triggers via `template_redirect` when `petitioner_live_preview` is set.
+     *
+     * @since 0.8.5
+     * @return void
+     */
     public static function render_preview()
     {
         if (!isset($_GET['petitioner_live_preview'])) {
@@ -65,6 +87,13 @@ class AV_Petitioner_Admin_Live_Preview
         exit;
     }
 
+    /**
+     * Renders the inline JavaScript that listens for `postMessage` events 
+     * to update the form styles and visibility in real-time.
+     *
+     * @since 0.8.5
+     * @return void
+     */
     public static function render_preview_script()
     {
         ?>

--- a/inc/admin-ui/settings/class-admin-live-preview.php
+++ b/inc/admin-ui/settings/class-admin-live-preview.php
@@ -65,10 +65,10 @@ class AV_Petitioner_Admin_Live_Preview
         if (isset($payload['custom_css'])) {
             $payload['custom_css'] = wp_strip_all_tags($payload['custom_css']);
         }
-        
+
         // Pass payload as overrides to the dynamic CSS generator
         $css = AV_Petitioner_Dynamic_CSS::generate_css($payload);
-        
+
         wp_send_json_success(['css' => $css]);
     }
 
@@ -94,16 +94,17 @@ class AV_Petitioner_Admin_Live_Preview
         send_frame_options_header();
 
         $form_id = isset($_GET['form_id']) ? intval($_GET['form_id']) : 0;
-        
+
         // Remove admin bar for the preview
         add_filter('show_admin_bar', '__return_false');
-        
+
         // Add the postMessage listener script to the footer
         add_action('wp_footer', [self::class, 'render_preview_script'], 999);
 
-        ?>
+?>
         <!DOCTYPE html>
         <html <?php language_attributes(); ?>>
+
         <head>
             <meta charset="<?php bloginfo('charset'); ?>">
             <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -111,13 +112,17 @@ class AV_Petitioner_Admin_Live_Preview
             <?php wp_head(); ?>
             <style>
                 body {
-                    background: transparent; 
+                    background: transparent;
                     margin: 0;
                     padding: 20px;
                 }
-                html { margin-top: 0 !important; }
+
+                html {
+                    margin-top: 0 !important;
+                }
             </style>
         </head>
+
         <body <?php body_class(); ?>>
             <div class="petitioner-preview-wrapper petitioner-preview" style="max-width: 800px; margin: 40px auto; padding: 20px;">
                 <?php
@@ -131,8 +136,9 @@ class AV_Petitioner_Admin_Live_Preview
             </div>
             <?php wp_footer(); ?>
         </body>
+
         </html>
-        <?php
+    <?php
         exit;
     }
 
@@ -146,7 +152,7 @@ class AV_Petitioner_Admin_Live_Preview
     public static function render_preview_script()
     {
         $admin_url = admin_url();
-        ?>
+    ?>
         <script>
             const adminOrigin = new URL('<?php echo esc_js($admin_url); ?>', window.location.href).origin;
 
@@ -157,13 +163,14 @@ class AV_Petitioner_Admin_Live_Preview
 
                 if (event.data && event.data.type === 'UPDATE_VISIBILITY') {
                     const payload = event.data.payload;
+                    if (!payload) return;
                     const root = document.querySelector('.petitioner');
                     if (!root) return;
-                    
+
                     // Toggle elements based on settings
                     const titleEl = document.querySelector('.petitioner__title');
                     if (titleEl) titleEl.style.display = payload.show_title ? 'block' : 'none';
-                    
+
                     const letterEl = document.querySelector('.petitioner__btn--letter');
                     if (letterEl) letterEl.style.display = payload.show_letter ? 'block' : 'none';
 
@@ -173,7 +180,7 @@ class AV_Petitioner_Admin_Live_Preview
 
                 if (event.data && event.data.type === 'UPDATE_CSS') {
                     const cssString = event.data.payload;
-                    
+
                     // Apply custom CSS string
                     let customStyleEl = document.getElementById('petitioner-dynamic-css');
                     if (!customStyleEl) {
@@ -185,6 +192,6 @@ class AV_Petitioner_Admin_Live_Preview
                 }
             });
         </script>
-        <?php
+<?php
     }
 }

--- a/inc/admin-ui/settings/class-admin-live-preview.php
+++ b/inc/admin-ui/settings/class-admin-live-preview.php
@@ -24,6 +24,27 @@ class AV_Petitioner_Admin_Live_Preview
     public static function init()
     {
         add_action('template_redirect', [self::class, 'render_preview']);
+        add_action('wp_ajax_petitioner_generate_preview_css', [self::class, 'generate_preview_css']);
+    }
+
+    /**
+     * AJAX handler to generate CSS for the live preview.
+     *
+     * @since 0.8.5
+     * @return void
+     */
+    public static function generate_preview_css()
+    {
+        if (!current_user_can('manage_options')) {
+            wp_send_json_error('Unauthorized');
+        }
+
+        $payload = isset($_POST['payload']) ? (array) $_POST['payload'] : [];
+        
+        // Pass payload as overrides to the dynamic CSS generator
+        $css = AV_Petitioner_Dynamic_CSS::generate_css($payload);
+        
+        wp_send_json_success(['css' => $css]);
     }
 
     /**
@@ -100,7 +121,7 @@ class AV_Petitioner_Admin_Live_Preview
         <script>
             // Listen for messages from the parent window
             window.addEventListener('message', function(event) {
-                if (event.data && event.data.type === 'UPDATE_SETTINGS') {
+                if (event.data && event.data.type === 'UPDATE_VISIBILITY') {
                     const payload = event.data.payload;
                     const root = document.querySelector('.petitioner');
                     if (!root) return;
@@ -114,99 +135,19 @@ class AV_Petitioner_Admin_Live_Preview
 
                     const goalEl = document.querySelector('.petitioner__goal');
                     if (goalEl) goalEl.style.display = payload.show_goal ? 'flex' : 'none';
+                }
 
-                    // Apply custom CSS
-                    let customStyleEl = document.getElementById('preview-custom-css');
+                if (event.data && event.data.type === 'UPDATE_CSS') {
+                    const cssString = event.data.payload;
+                    
+                    // Apply custom CSS string
+                    let customStyleEl = document.getElementById('petitioner-dynamic-css');
                     if (!customStyleEl) {
                         customStyleEl = document.createElement('style');
-                        customStyleEl.id = 'preview-custom-css';
+                        customStyleEl.id = 'petitioner-dynamic-css';
                         document.head.appendChild(customStyleEl);
                     }
-                    customStyleEl.textContent = payload.custom_css || '';
-
-                    const setVar = (name, val) => {
-                        if (val) {
-                            root.style.setProperty(name, val, 'important');
-                        } else {
-                            root.style.removeProperty(name);
-                        }
-                    };
-
-                    // Colors
-                    setVar('--ptr-color-primary', payload.primary_color);
-                    setVar('--ptr-color-dark', payload.dark_color);
-                    setVar('--ptr-color-grey', payload.grey_color);
-
-                    // Border Radius
-                    if (payload.border_radius) {
-                        setVar('--ptr-input-border-radius', `var(--ptr-border-radius-${payload.border_radius})`);
-                        setVar('--ptr-button-border-radius', `var(--ptr-border-radius-${payload.border_radius})`);
-                        
-                        let wrapperRadius = payload.border_radius === 'full' ? 'lg' : payload.border_radius;
-                        setVar('--ptr-wrapper-radius', `var(--ptr-border-radius-${wrapperRadius})`);
-                    } else {
-                        root.style.removeProperty('--ptr-input-border-radius');
-                        root.style.removeProperty('--ptr-button-border-radius');
-                        root.style.removeProperty('--ptr-wrapper-radius');
-                    }
-
-                    // Base Font Size
-                    if (payload.base_font_size) {
-                        setVar('--ptr-label-font-size', `var(--ptr-fs-${payload.base_font_size})`);
-                    } else {
-                        root.style.removeProperty('--ptr-label-font-size');
-                    }
-
-                    // Button Font Size
-                    if (payload.button_font_size) {
-                        setVar('--ptr-btn-font-size', `var(--ptr-fs-${payload.button_font_size})`);
-                    } else {
-                        root.style.removeProperty('--ptr-btn-font-size');
-                    }
-
-                    // Spacing
-                    if (payload.field_spacing) {
-                        setVar('--ptr-input-margin-bottom', `var(--ptr-spacer-${payload.field_spacing})`);
-                    } else {
-                        root.style.removeProperty('--ptr-input-margin-bottom');
-                    }
-
-                    // Border width
-                    if (payload.input_border_width) {
-                        setVar('--ptr-input-border-width', payload.input_border_width);
-                    } else {
-                        root.style.removeProperty('--ptr-input-border-width');
-                    }
-
-                    // Input Size
-                    if (payload.input_size) {
-                        switch(payload.input_size) {
-                            case 'sm':
-                                setVar('--ptr-input-line-height', '24px');
-                                setVar('--ptr-input-spacing-y', '4px');
-                                setVar('--ptr-label-line-height', '1.4');
-                                break;
-                            case 'md':
-                                setVar('--ptr-input-line-height', '24px');
-                                setVar('--ptr-input-spacing-y', '8px');
-                                root.style.removeProperty('--ptr-label-line-height');
-                                break;
-                            case 'lg':
-                                setVar('--ptr-input-line-height', '32px');
-                                setVar('--ptr-input-spacing-y', '8px');
-                                root.style.removeProperty('--ptr-label-line-height');
-                                break;
-                            case 'xl':
-                                setVar('--ptr-input-line-height', '40px');
-                                setVar('--ptr-input-spacing-y', '0.7rem');
-                                root.style.removeProperty('--ptr-label-line-height');
-                                break;
-                        }
-                    } else {
-                        root.style.removeProperty('--ptr-input-line-height');
-                        root.style.removeProperty('--ptr-input-spacing-y');
-                        root.style.removeProperty('--ptr-label-line-height');
-                    }
+                    customStyleEl.textContent = cssString || '';
                 }
             });
         </script>

--- a/inc/admin-ui/settings/class-admin-live-preview.php
+++ b/inc/admin-ui/settings/class-admin-live-preview.php
@@ -50,13 +50,20 @@ class AV_Petitioner_Admin_Live_Preview
         </head>
         <body>
             <?php
-            $petitions = get_posts([
-                'post_type' => 'petitioner-petition',
-                'posts_per_page' => 1,
-                'post_status' => 'any'
-            ]);
+            $form_id = isset($_GET['form_id']) ? intval($_GET['form_id']) : 0;
+            $petitions = [];
 
-            if (!empty($petitions)) {
+            if ($form_id) {
+                $petitions = [get_post($form_id)];
+            } else {
+                $petitions = get_posts([
+                    'post_type' => 'petitioner-petition',
+                    'posts_per_page' => 1,
+                    'post_status' => 'any'
+                ]);
+            }
+
+            if (!empty($petitions) && $petitions[0]) {
                 $frontend_ui = new AV_Petitioner_Frontend_UI();
                 echo $frontend_ui->display_form(['id' => $petitions[0]->ID]);
             } else {

--- a/inc/admin-ui/settings/class-admin-live-preview.php
+++ b/inc/admin-ui/settings/class-admin-live-preview.php
@@ -39,6 +39,8 @@ class AV_Petitioner_Admin_Live_Preview
             wp_send_json_error('Unauthorized');
         }
 
+        check_ajax_referer('petitioner_nonce', 'petitioner_nonce');
+
         $payload = isset($_POST['payload']) ? (array) $_POST['payload'] : [];
         
         // Pass payload as overrides to the dynamic CSS generator

--- a/inc/admin-ui/settings/class-admin-live-preview.php
+++ b/inc/admin-ui/settings/class-admin-live-preview.php
@@ -15,6 +15,8 @@ if (!defined('ABSPATH')) {
  */
 class AV_Petitioner_Admin_Live_Preview
 {
+    const NONCE_ACTION = 'petitioner_generate_preview_css';
+
     /**
      * Initializes the class and hooks into WordPress.
      *
@@ -25,6 +27,19 @@ class AV_Petitioner_Admin_Live_Preview
     {
         add_action('template_redirect', [self::class, 'render_preview']);
         add_action('wp_ajax_petitioner_generate_preview_css', [self::class, 'generate_preview_css']);
+        add_filter('av_petitioner_info_settings', [self::class, 'add_preview_nonce']);
+    }
+
+    /**
+     * Injects the dedicated preview nonce into the localized settings data.
+     *
+     * @param array $petitioner_info
+     * @return array
+     */
+    public static function add_preview_nonce($petitioner_info)
+    {
+        $petitioner_info['preview_nonce'] = wp_create_nonce(self::NONCE_ACTION);
+        return $petitioner_info;
     }
 
     /**
@@ -39,7 +54,7 @@ class AV_Petitioner_Admin_Live_Preview
             wp_send_json_error('Unauthorized');
         }
 
-        check_ajax_referer('petitioner_nonce', 'petitioner_nonce');
+        check_ajax_referer(self::NONCE_ACTION, 'petitioner_nonce');
 
         $payload = isset($_POST['payload']) ? (array) $_POST['payload'] : [];
         

--- a/inc/admin-ui/settings/class-admin-live-preview.php
+++ b/inc/admin-ui/settings/class-admin-live-preview.php
@@ -67,6 +67,9 @@ class AV_Petitioner_Admin_Live_Preview
             wp_die('Unauthorized', 403);
         }
 
+        // Prevent clickjacking by ensuring this can only be framed by the same origin
+        send_frame_options_header();
+
         $form_id = isset($_GET['form_id']) ? intval($_GET['form_id']) : 0;
         
         // Remove admin bar for the preview
@@ -119,10 +122,16 @@ class AV_Petitioner_Admin_Live_Preview
      */
     public static function render_preview_script()
     {
+        $admin_url = admin_url();
         ?>
         <script>
+            const adminOrigin = new URL('<?php echo esc_js($admin_url); ?>', window.location.href).origin;
+
             // Listen for messages from the parent window
             window.addEventListener('message', function(event) {
+                // Verify the message comes from the WordPress admin dashboard
+                if (event.origin !== adminOrigin) return;
+
                 if (event.data && event.data.type === 'UPDATE_VISIBILITY') {
                     const payload = event.data.payload;
                     const root = document.querySelector('.petitioner');

--- a/inc/admin-ui/settings/class-admin-settings-ui.php
+++ b/inc/admin-ui/settings/class-admin-settings-ui.php
@@ -158,10 +158,27 @@ class AV_Petitioner_Admin_Settings_UI
             } else {
                 $petitioner_info[$key] = $option_values[$key];
             }
+        }
+        
+        $petitions = get_posts([
+            'post_type' => 'petitioner-petition',
+            'posts_per_page' => -1,
+            'post_status' => 'any'
+        ]);
+        $petition_list = [];
+        foreach ($petitions as $p) {
+            $petition_list[] = [
+                'id' => $p->ID,
+                'title' => !empty($p->post_title) ? $p->post_title : __('(No Title)', 'petitioner')
+            ];
+        }
+
         $petitioner_info['default_values'] = [
             "colors" => $this->default_colors,
             "labels" => $this->get_default_labels()
         ];
+        
+        $petitioner_info['petitions'] = $petition_list;
 
         /**
          * Filter to modify petitioner data that is sent to the edit screen

--- a/inc/admin-ui/settings/class-admin-settings-ui.php
+++ b/inc/admin-ui/settings/class-admin-settings-ui.php
@@ -59,9 +59,6 @@ class AV_Petitioner_Admin_Settings_UI
                 wp_enqueue_code_editor(array('type' => 'text/css'));
                 wp_enqueue_script('wp-theme-plugin-editor');
                 wp_enqueue_style('wp-codemirror');
-                wp_add_inline_script('wp-theme-plugin-editor', "jQuery(document).ready(function($) {
-                    wp.codeEditor.initialize($('#petitionerCode'), {type: 'text/css'});
-                });", true);
 
                 wp_enqueue_style('wp-color-picker');
                 wp_enqueue_script('wp-color-picker');

--- a/inc/admin-ui/settings/class-admin-settings-ui.php
+++ b/inc/admin-ui/settings/class-admin-settings-ui.php
@@ -163,6 +163,8 @@ class AV_Petitioner_Admin_Settings_UI
             "colors" => $this->default_colors,
             "labels" => $this->get_default_labels()
         ];
+        
+        $petitioner_info['home_url'] = home_url('/');
 
         /**
          * Filter to modify petitioner data that is sent to the edit screen

--- a/inc/admin-ui/settings/class-admin-settings-ui.php
+++ b/inc/admin-ui/settings/class-admin-settings-ui.php
@@ -159,26 +159,10 @@ class AV_Petitioner_Admin_Settings_UI
                 $petitioner_info[$key] = $option_values[$key];
             }
         }
-        
-        $petitions = get_posts([
-            'post_type' => 'petitioner-petition',
-            'posts_per_page' => -1,
-            'post_status' => 'any'
-        ]);
-        $petition_list = [];
-        foreach ($petitions as $p) {
-            $petition_list[] = [
-                'id' => $p->ID,
-                'title' => !empty($p->post_title) ? $p->post_title : __('(No Title)', 'petitioner')
-            ];
-        }
-
         $petitioner_info['default_values'] = [
             "colors" => $this->default_colors,
             "labels" => $this->get_default_labels()
         ];
-        
-        $petitioner_info['petitions'] = $petition_list;
 
         /**
          * Filter to modify petitioner data that is sent to the edit screen

--- a/inc/admin-ui/settings/class-admin-settings-ui.php
+++ b/inc/admin-ui/settings/class-admin-settings-ui.php
@@ -158,8 +158,6 @@ class AV_Petitioner_Admin_Settings_UI
             } else {
                 $petitioner_info[$key] = $option_values[$key];
             }
-        }
-
         $petitioner_info['default_values'] = [
             "colors" => $this->default_colors,
             "labels" => $this->get_default_labels()

--- a/inc/class-setup.php
+++ b/inc/class-setup.php
@@ -47,6 +47,10 @@ class AV_Petitioner_Setup
                 new AV_Petitioner_Admin_Component_Preview_UI();
             }
 
+            if (class_exists('AV_Petitioner_Admin_Live_Preview')) {
+                AV_Petitioner_Admin_Live_Preview::init();
+            }
+
             // shared admin settings
             if (class_exists('AV_Petitioner_Admin_Shared')) {
                 new AV_Petitioner_Admin_Shared();

--- a/inc/class-setup.php
+++ b/inc/class-setup.php
@@ -257,7 +257,7 @@ class AV_Petitioner_Setup
         }
 
         wp_enqueue_style('petitioner-admin-style', plugin_dir_url(dirname(__FILE__)) . 'dist/admin.css', array(), AV_PETITIONER_PLUGIN_VERSION);
-        wp_enqueue_script('petitioner-admin-script', plugin_dir_url(dirname(__FILE__)) . 'dist/admin.js', ['wp-blocks', 'wp-block-editor', 'wp-element', 'wp-components', 'wp-data', 'wp-i18n', 'wp-hooks'], AV_PETITIONER_PLUGIN_VERSION, true);
+        wp_enqueue_script('petitioner-admin-script', plugin_dir_url(dirname(__FILE__)) . 'dist/admin.js', ['wp-blocks', 'wp-block-editor', 'wp-element', 'wp-components', 'wp-data', 'wp-core-data', 'wp-i18n', 'wp-hooks'], AV_PETITIONER_PLUGIN_VERSION, true);
 
         wp_localize_script('petitioner-admin-script', 'petitionerFormSettings', [
             'actionPath' => admin_url('admin-ajax.php') . '?action=petitioner_form_submit',

--- a/inc/frontend/class-dynamic-css.php
+++ b/inc/frontend/class-dynamic-css.php
@@ -136,26 +136,43 @@ class AV_Petitioner_Dynamic_CSS
     }
 
     /**
-     * Generates all dynamic CSS styles based on saved options.
+     * Helper to get a setting either from overrides or the database.
      *
+     * @param string $key The database option key.
+     * @param array $overrides Optional array of values keyed without the petitioner_ prefix.
+     * @return mixed
+     */
+    private static function get_setting($key, $overrides = [])
+    {
+        $override_key = str_replace('petitioner_', '', $key);
+        if (isset($overrides[$override_key])) {
+            return $overrides[$override_key];
+        }
+        return get_option($key, '');
+    }
+
+    /**
+     * Generates all dynamic CSS styles based on saved options or overrides.
+     *
+     * @param array $overrides Optional overrides for live preview.
      * @return string The generated CSS string.
      */
-    public static function generate_css()
+    public static function generate_css($overrides = [])
     {
         $dynamic_styles = '';
-        $dynamic_styles .= self::get_color_styles();
-        $dynamic_styles .= self::get_border_radius_styles();
-        $dynamic_styles .= self::get_font_styles();
-        $dynamic_styles .= self::get_spacing_styles();
-        $dynamic_styles .= self::get_border_styles();
-        $dynamic_styles .= self::get_input_size_styles();
+        $dynamic_styles .= self::get_color_styles($overrides);
+        $dynamic_styles .= self::get_border_radius_styles($overrides);
+        $dynamic_styles .= self::get_font_styles($overrides);
+        $dynamic_styles .= self::get_spacing_styles($overrides);
+        $dynamic_styles .= self::get_border_styles($overrides);
+        $dynamic_styles .= self::get_input_size_styles($overrides);
 
         $custom_css = '';
         if (!empty($dynamic_styles)) {
             $custom_css .= '.petitioner {' . $dynamic_styles . ' } ';
         }
 
-        $custom_css .= get_option('petitioner_custom_css', '');
+        $custom_css .= self::get_setting('petitioner_custom_css', $overrides);
 
         return $custom_css;
     }
@@ -163,23 +180,24 @@ class AV_Petitioner_Dynamic_CSS
     /**
      * Generates CSS variables for color settings.
      *
+     * @param array $overrides Optional overrides.
      * @return string The color CSS styles.
      */
-    private static function get_color_styles()
+    private static function get_color_styles($overrides = [])
     {
         $styles = '';
 
-        $primary = sanitize_hex_color(get_option('petitioner_primary_color', ''));
+        $primary = sanitize_hex_color(self::get_setting('petitioner_primary_color', $overrides));
         if (!empty($primary)) {
             $styles .= '--ptr-color-primary: ' . $primary . '!important;';
         }
 
-        $dark = sanitize_hex_color(get_option('petitioner_dark_color', ''));
+        $dark = sanitize_hex_color(self::get_setting('petitioner_dark_color', $overrides));
         if (!empty($dark)) {
             $styles .= '--ptr-color-dark: ' . $dark . '!important;';
         }
 
-        $grey = sanitize_hex_color(get_option('petitioner_grey_color', ''));
+        $grey = sanitize_hex_color(self::get_setting('petitioner_grey_color', $overrides));
         if (!empty($grey)) {
             $styles .= '--ptr-color-grey: ' . $grey . '!important;';
         }
@@ -190,12 +208,13 @@ class AV_Petitioner_Dynamic_CSS
     /**
      * Generates CSS variables for border radius settings.
      *
+     * @param array $overrides Optional overrides.
      * @return string The border radius CSS styles.
      */
-    private static function get_border_radius_styles()
+    private static function get_border_radius_styles($overrides = [])
     {
         $styles = '';
-        $radius = get_option('petitioner_border_radius', '');
+        $radius = self::get_setting('petitioner_border_radius', $overrides);
 
         if (self::is_valid_option($radius, 'border_radius')) {
             $styles .= '--ptr-input-border-radius: var(--ptr-border-radius-' . $radius . ')!important;';
@@ -212,18 +231,19 @@ class AV_Petitioner_Dynamic_CSS
     /**
      * Generates CSS variables for font size settings.
      *
+     * @param array $overrides Optional overrides.
      * @return string The font size CSS styles.
      */
-    private static function get_font_styles()
+    private static function get_font_styles($overrides = [])
     {
         $styles = '';
 
-        $base = get_option('petitioner_base_font_size', '');
+        $base = self::get_setting('petitioner_base_font_size', $overrides);
         if (self::is_valid_option($base, 'base_font_size')) {
             $styles .= '--ptr-label-font-size: var(--ptr-fs-' . $base . ')!important;';
         }
 
-        $btn = get_option('petitioner_button_font_size', '');
+        $btn = self::get_setting('petitioner_button_font_size', $overrides);
         if (self::is_valid_option($btn, 'button_font_size')) {
             $styles .= '--ptr-btn-font-size: var(--ptr-fs-' . $btn . ')!important;';
         }
@@ -234,12 +254,13 @@ class AV_Petitioner_Dynamic_CSS
     /**
      * Generates CSS variables for field spacing settings.
      *
+     * @param array $overrides Optional overrides.
      * @return string The field spacing CSS styles.
      */
-    private static function get_spacing_styles()
+    private static function get_spacing_styles($overrides = [])
     {
         $styles = '';
-        $spacing = get_option('petitioner_field_spacing', '');
+        $spacing = self::get_setting('petitioner_field_spacing', $overrides);
 
         if (self::is_valid_option($spacing, 'field_spacing')) {
             $styles .= '--ptr-input-margin-bottom: var(--ptr-spacer-' . $spacing . ')!important;';
@@ -251,12 +272,13 @@ class AV_Petitioner_Dynamic_CSS
     /**
      * Generates CSS variables for input border width settings.
      *
+     * @param array $overrides Optional overrides.
      * @return string The input border width CSS styles.
      */
-    private static function get_border_styles()
+    private static function get_border_styles($overrides = [])
     {
         $styles = '';
-        $width = get_option('petitioner_input_border_width', '');
+        $width = self::get_setting('petitioner_input_border_width', $overrides);
 
         if (self::is_valid_option($width, 'input_border_width')) {
             $styles .= '--ptr-input-border-width: ' . $width . '!important;';
@@ -268,12 +290,13 @@ class AV_Petitioner_Dynamic_CSS
     /**
      * Generates CSS variables for input size settings.
      *
+     * @param array $overrides Optional overrides.
      * @return string The input size CSS styles.
      */
-    private static function get_input_size_styles()
+    private static function get_input_size_styles($overrides = [])
     {
         $styles = '';
-        $size = get_option('petitioner_input_size', '');
+        $size = self::get_setting('petitioner_input_size', $overrides);
 
         if (empty($size) || !self::is_valid_option($size, 'input_size')) {
             return $styles;

--- a/inc/submissions/class-submissions-controller.php
+++ b/inc/submissions/class-submissions-controller.php
@@ -315,7 +315,7 @@ class AV_Petitioner_Submissions_Controller
             $fetch_settings['order'] = $order;
         }
 
-        if ($orderby && in_array($orderby, $fields, true)) {
+        if ($orderby && in_array($orderby, $public_fields, true)) {
             $fetch_settings['orderby'] = $orderby;
         }
 

--- a/petitioner.php
+++ b/petitioner.php
@@ -62,6 +62,7 @@ require_once AV_PETITIONER_PLUGIN_DIR . 'inc/frontend/class-dynamic-css.php';
 require_once AV_PETITIONER_PLUGIN_DIR . 'inc/frontend/class-shortcodes.php';
 require_once AV_PETITIONER_PLUGIN_DIR . 'inc/admin-ui/edit-form/class-admin-edit-ui.php';
 require_once AV_PETITIONER_PLUGIN_DIR . 'inc/admin-ui/settings/class-admin-settings-ui.php';
+require_once AV_PETITIONER_PLUGIN_DIR . 'inc/admin-ui/settings/class-admin-live-preview.php';
 require_once AV_PETITIONER_PLUGIN_DIR . 'inc/admin-ui/class-admin-component-preview-ui.php';
 require_once AV_PETITIONER_PLUGIN_DIR . 'inc/admin-ui/class-admin-shared.php';
 require_once AV_PETITIONER_PLUGIN_DIR . 'inc/gutenberg/class-gutenberg.php';
@@ -72,6 +73,8 @@ require_once AV_PETITIONER_PLUGIN_DIR . 'inc/labels/class-label-overrides.php';
 
 $petitioner_setup = new AV_Petitioner_Setup();
 
+AV_Petitioner_Dynamic_CSS::init();
+AV_Petitioner_Admin_Live_Preview::init();
 new AV_Email_Confirmations();
 
 register_activation_hook(__FILE__, array('AV_Petitioner_Setup', 'plugin_activation'));

--- a/petitioner.php
+++ b/petitioner.php
@@ -73,8 +73,6 @@ require_once AV_PETITIONER_PLUGIN_DIR . 'inc/labels/class-label-overrides.php';
 
 $petitioner_setup = new AV_Petitioner_Setup();
 
-AV_Petitioner_Dynamic_CSS::init();
-AV_Petitioner_Admin_Live_Preview::init();
 new AV_Email_Confirmations();
 
 register_activation_hook(__FILE__, array('AV_Petitioner_Setup', 'plugin_activation'));

--- a/src/js/admin/components/CodeEditor.tsx
+++ b/src/js/admin/components/CodeEditor.tsx
@@ -5,37 +5,46 @@ interface CodeEditorProps {
 	help?: string;
 	code?: string;
 	onChange?: (code: string) => void;
+	/** We want to reinitialize it if the active tab is different on load so it calculates the styles correctly */
+	isActive?: boolean;
 }
 
-export default function CodeEditor({ title = '', help = '', code = '', onChange }: CodeEditorProps) {
+export default function CodeEditor({ title = '', help = '', code = '', onChange, isActive = true }: CodeEditorProps) {
 	const textareaRef = useRef<HTMLTextAreaElement>(null);
-	const initializedRef = useRef(false);
 	const onChangeRef = useRef(onChange);
+	const editorRef = useRef<any>(null);
 
 	useEffect(() => {
 		onChangeRef.current = onChange;
 	}, [onChange]);
 
 	useEffect(() => {
-		if (window.wp?.codeEditor && textareaRef.current && !initializedRef.current) {
-			initializedRef.current = true;
-
+		if (window.wp?.codeEditor && textareaRef.current && !editorRef.current) {
 			const editorConfig = { type: 'text/css' };
-			const editorInstance = window.wp.codeEditor.initialize(textareaRef.current, editorConfig);
+			editorRef.current = window.wp.codeEditor.initialize(textareaRef.current, editorConfig);
 
-			if (editorInstance?.codemirror) {
+			if (editorRef.current?.codemirror) {
 				let timeout: NodeJS.Timeout;
-				editorInstance.codemirror.on('change', () => {
+				editorRef.current.codemirror.on('change', () => {
 					clearTimeout(timeout);
 					timeout = setTimeout(() => {
 						if (onChangeRef.current) {
-							onChangeRef.current(editorInstance.codemirror.getValue());
+							onChangeRef.current(editorRef.current.codemirror.getValue());
 						}
 					}, 500);
 				});
 			}
 		}
 	}, []);
+
+	useEffect(() => {
+		if (isActive && editorRef.current?.codemirror) {
+			// A small delay ensures the container has finished rendering as visible
+			setTimeout(() => {
+				editorRef.current.codemirror.refresh();
+			}, 0);
+		}
+	}, [isActive]);
 
 	return (
 		<div>

--- a/src/js/admin/components/CodeEditor.tsx
+++ b/src/js/admin/components/CodeEditor.tsx
@@ -19,7 +19,7 @@ export default function CodeEditor({ title = '', help = '', code = '', onChange,
 	}, [onChange]);
 
 	useEffect(() => {
-		if (window.wp?.codeEditor && textareaRef.current && !editorRef.current) {
+		if (isActive && window.wp?.codeEditor && textareaRef.current && !editorRef.current) {
 			const editorConfig = { type: 'text/css' };
 			editorRef.current = window.wp.codeEditor.initialize(textareaRef.current, editorConfig);
 
@@ -34,11 +34,7 @@ export default function CodeEditor({ title = '', help = '', code = '', onChange,
 					}, 500);
 				});
 			}
-		}
-	}, []);
-
-	useEffect(() => {
-		if (isActive && editorRef.current?.codemirror) {
+		} else if (isActive && editorRef.current?.codemirror) {
 			// A small delay ensures the container has finished rendering as visible
 			setTimeout(() => {
 				editorRef.current.codemirror.refresh();

--- a/src/js/admin/components/CodeEditor.tsx
+++ b/src/js/admin/components/CodeEditor.tsx
@@ -1,4 +1,35 @@
-export default function CodeEditor({ title = '', help = '', code = '' }) {
+import { useEffect, useRef } from '@wordpress/element';
+
+interface CodeEditorProps {
+	title?: string;
+	help?: string;
+	code?: string;
+	onChange?: (code: string) => void;
+}
+
+export default function CodeEditor({ title = '', help = '', code = '', onChange }: CodeEditorProps) {
+	const textareaRef = useRef<HTMLTextAreaElement>(null);
+	const initializedRef = useRef(false);
+
+	useEffect(() => {
+		if (window.wp?.codeEditor && textareaRef.current && !initializedRef.current) {
+			initializedRef.current = true;
+			
+			const editorConfig = { type: 'text/css' };
+			const editorInstance = window.wp.codeEditor.initialize(textareaRef.current, editorConfig);
+			
+			if (onChange && editorInstance?.codemirror) {
+				let timeout: NodeJS.Timeout;
+				editorInstance.codemirror.on('change', () => {
+					clearTimeout(timeout);
+					timeout = setTimeout(() => {
+						onChange(editorInstance.codemirror.getValue());
+					}, 500);
+				});
+			}
+		}
+	}, [onChange]);
+
 	return (
 		<div>
 			<p>
@@ -6,14 +37,14 @@ export default function CodeEditor({ title = '', help = '', code = '' }) {
 				<span>{help}</span>
 			</p>
 			<textarea
+				ref={textareaRef}
 				name="petitioner_custom_css"
 				id="petitionerCode"
 				rows={10}
 				cols={50}
 				className="large-text code petitioner-code-editor"
-			>
-				{code}
-			</textarea>
+				defaultValue={code}
+			/>
 		</div>
 	);
 }

--- a/src/js/admin/components/CodeEditor.tsx
+++ b/src/js/admin/components/CodeEditor.tsx
@@ -10,25 +10,32 @@ interface CodeEditorProps {
 export default function CodeEditor({ title = '', help = '', code = '', onChange }: CodeEditorProps) {
 	const textareaRef = useRef<HTMLTextAreaElement>(null);
 	const initializedRef = useRef(false);
+	const onChangeRef = useRef(onChange);
+
+	useEffect(() => {
+		onChangeRef.current = onChange;
+	}, [onChange]);
 
 	useEffect(() => {
 		if (window.wp?.codeEditor && textareaRef.current && !initializedRef.current) {
 			initializedRef.current = true;
-			
+
 			const editorConfig = { type: 'text/css' };
 			const editorInstance = window.wp.codeEditor.initialize(textareaRef.current, editorConfig);
-			
-			if (onChange && editorInstance?.codemirror) {
+
+			if (editorInstance?.codemirror) {
 				let timeout: NodeJS.Timeout;
 				editorInstance.codemirror.on('change', () => {
 					clearTimeout(timeout);
 					timeout = setTimeout(() => {
-						onChange(editorInstance.codemirror.getValue());
+						if (onChangeRef.current) {
+							onChangeRef.current(editorInstance.codemirror.getValue());
+						}
 					}, 500);
 				});
 			}
 		}
-	}, [onChange]);
+	}, []);
 
 	return (
 		<div>

--- a/src/js/admin/components/Tabs/index.tsx
+++ b/src/js/admin/components/Tabs/index.tsx
@@ -1,5 +1,5 @@
 import { TabPanel } from '@wordpress/components';
-import { useState, useCallback } from '@wordpress/element';
+import { useState, useCallback, isValidElement, cloneElement } from '@wordpress/element';
 import type { TabPanelProps, Tab } from './consts';
 import { updateActiveTabURL } from '@admin/utilities';
 
@@ -44,7 +44,7 @@ export default function Tabs(props: TabPanelProps) {
 							data-testid={`ptr-tab-${el.name}`}
 							className={`petitioner-tab petitioner-tab ${activeTab === el.name ? 'active' : ''}`}
 						>
-							{el.renderingEl}
+							{isValidElement(el.renderingEl) ? cloneElement(el.renderingEl, { isActive: activeTab === el.name } as any) : el.renderingEl}
 						</div>
 					);
 				})}

--- a/src/js/admin/globals.d.ts
+++ b/src/js/admin/globals.d.ts
@@ -34,6 +34,7 @@ declare global {
 				defaults: Record<string, unknown>;
 				draggable: unknown[];
 			};
+			petitions?: Array<{ id: number; title: string; [key: string]: any }>;
 		};
 		petitionerComponents?: PetitionerComponents;
 	}

--- a/src/js/admin/globals.d.ts
+++ b/src/js/admin/globals.d.ts
@@ -37,6 +37,11 @@ declare global {
 			home_url?: string;
 			petitions?: Array<{ id: number; title: string; [key: string]: any }>;
 		};
+		wp?: {
+			codeEditor?: {
+				initialize: (el: HTMLElement | string, config: any) => any;
+			};
+		};
 		petitionerComponents?: PetitionerComponents;
 	}
 }

--- a/src/js/admin/globals.d.ts
+++ b/src/js/admin/globals.d.ts
@@ -34,6 +34,7 @@ declare global {
 				defaults: Record<string, unknown>;
 				draggable: unknown[];
 			};
+			home_url?: string;
 			petitions?: Array<{ id: number; title: string; [key: string]: any }>;
 		};
 		petitionerComponents?: PetitionerComponents;

--- a/src/js/admin/sections/SettingsFields/FormPreview/consts.ts
+++ b/src/js/admin/sections/SettingsFields/FormPreview/consts.ts
@@ -1,0 +1,1 @@
+export const PREVIEW_UPDATE_EVENT = 'UPDATE_SETTINGS';

--- a/src/js/admin/sections/SettingsFields/FormPreview/consts.ts
+++ b/src/js/admin/sections/SettingsFields/FormPreview/consts.ts
@@ -1,1 +1,3 @@
 export const PREVIEW_UPDATE_EVENT = 'UPDATE_SETTINGS';
+
+export const LOCAL_STORAGE_KEY = 'petitionerFormPreviewID';

--- a/src/js/admin/sections/SettingsFields/FormPreview/hooks.ts
+++ b/src/js/admin/sections/SettingsFields/FormPreview/hooks.ts
@@ -1,7 +1,7 @@
 import { useRef, useState, useCallback, useEffect } from "@wordpress/element";
 import { useSelect } from "@wordpress/data";
 import { useSettingsFormContext } from "@admin/context/SettingsContext";
-import { fetchPreviewCSS } from "./utilities";
+import { fetchPreviewCSS, localClearSavedFormID, localSaveFormID, localGetSavedFormId } from "./utilities";
 
 export const useFormPreview = () => {
     const iframeRef = useRef<HTMLIFrameElement>(null);
@@ -16,7 +16,14 @@ export const useFormPreview = () => {
         });
     }, []);
 
-    const [selectedFormId, setSelectedFormId] = useState(0);
+    const [selectedFormId, setSelectedFormId] = useState(localGetSavedFormId() ?? 0);
+
+    const onFormSelect = (id: number) => {
+        localClearSavedFormID();
+        setIframeLoaded(false);
+        setSelectedFormId(id);
+        localSaveFormID(id);
+    };
 
     useEffect(() => {
         if (Array.isArray(petitions) && petitions.length > 0 && selectedFormId === 0) {
@@ -85,7 +92,7 @@ export const useFormPreview = () => {
         setIframeLoaded,
         previewUrl,
         selectedFormId,
-        setSelectedFormId,
+        onFormSelect,
         petitions,
         syncPreview,
     }

--- a/src/js/admin/sections/SettingsFields/FormPreview/hooks.ts
+++ b/src/js/admin/sections/SettingsFields/FormPreview/hooks.ts
@@ -1,0 +1,86 @@
+import { useRef, useState, useCallback, useEffect } from "@wordpress/element";
+import { useSelect } from "@wordpress/data";
+import { useSettingsFormContext } from "@admin/context/SettingsContext";
+import { fetchPreviewCSS } from "./utilities";
+
+export const useFormPreview = () => {
+    const iframeRef = useRef<HTMLIFrameElement>(null);
+    const abortControllerRef = useRef<AbortController | null>(null);
+    const { formState } = useSettingsFormContext();
+    const [iframeLoaded, setIframeLoaded] = useState(false);
+
+    const petitions = useSelect((select) => {
+        // @ts-ignore - core-data types might not be fully available
+        return select('core').getEntityRecords('postType', 'petitioner-petition', {
+            per_page: -1,
+        });
+    }, []);
+
+    const [selectedFormId, setSelectedFormId] = useState(0);
+
+    useEffect(() => {
+        if (Array.isArray(petitions) && petitions.length > 0 && selectedFormId === 0) {
+            setSelectedFormId(petitions[0].id);
+        }
+    }, [petitions, selectedFormId]);
+
+    const syncPreview = useCallback(async () => {
+        if (!iframeRef.current?.contentWindow) return;
+
+        const targetOrigin = new URL(
+            window.petitionerData?.home_url || '/',
+            window.location.href
+        ).origin;
+
+        // 1. Send visibility updates instantly
+        iframeRef.current.contentWindow.postMessage(
+            { type: 'UPDATE_VISIBILITY', payload: formState },
+            targetOrigin
+        );
+
+        // Cancel any pending CSS generation requests
+        if (abortControllerRef.current) {
+            abortControllerRef.current.abort();
+        }
+        abortControllerRef.current = new AbortController();
+
+        // 2. Fetch compiled CSS via AJAX
+        fetchPreviewCSS({
+            formState,
+            abortSignal: abortControllerRef.current.signal,
+            onSuccess: (css) => {
+                iframeRef.current?.contentWindow?.postMessage(
+                    { type: 'UPDATE_CSS', payload: css },
+                    targetOrigin
+                );
+            },
+            onError: (msg) => {
+                console.error(msg);
+            },
+        });
+    }, [formState]);
+
+    // Sync settings to the iframe via AJAX + postMessage
+    useEffect(() => {
+        if (!iframeLoaded) return;
+
+        // Debounce the AJAX call
+        const timeout = setTimeout(() => {
+            syncPreview();
+        }, 300);
+
+        return () => clearTimeout(timeout);
+    }, [syncPreview, iframeLoaded]);
+
+    const previewUrl = `${window.petitionerData?.home_url || '/'}?petitioner_live_preview=1&form_id=${selectedFormId}`;
+
+    return {
+        iframeRef,
+        setIframeLoaded,
+        previewUrl,
+        selectedFormId,
+        setSelectedFormId,
+        petitions,
+        syncPreview,
+    }
+}

--- a/src/js/admin/sections/SettingsFields/FormPreview/hooks.ts
+++ b/src/js/admin/sections/SettingsFields/FormPreview/hooks.ts
@@ -69,7 +69,13 @@ export const useFormPreview = () => {
             syncPreview();
         }, 300);
 
-        return () => clearTimeout(timeout);
+        return () => {
+            clearTimeout(timeout);
+            // Abort any in-flight request when unmounting OR when dependencies change
+            if (abortControllerRef.current) {
+                abortControllerRef.current.abort();
+            }
+        }
     }, [syncPreview, iframeLoaded]);
 
     const previewUrl = `${window.petitionerData?.home_url || '/'}?petitioner_live_preview=1&form_id=${selectedFormId}`;

--- a/src/js/admin/sections/SettingsFields/FormPreview/hooks.ts
+++ b/src/js/admin/sections/SettingsFields/FormPreview/hooks.ts
@@ -1,7 +1,7 @@
 import { useRef, useState, useCallback, useEffect } from "@wordpress/element";
 import { useSelect } from "@wordpress/data";
 import { useSettingsFormContext } from "@admin/context/SettingsContext";
-import { fetchPreviewCSS, localClearSavedFormID, localSaveFormID, localGetSavedFormId } from "./utilities";
+import { fetchPreviewCSS, localSaveFormID, localGetSavedFormId } from "./utilities";
 
 export const useFormPreview = () => {
     const iframeRef = useRef<HTMLIFrameElement>(null);
@@ -19,7 +19,6 @@ export const useFormPreview = () => {
     const [selectedFormId, setSelectedFormId] = useState(localGetSavedFormId() ?? 0);
 
     const onFormSelect = (id: number) => {
-        localClearSavedFormID();
         setIframeLoaded(false);
         setSelectedFormId(id);
         localSaveFormID(id);

--- a/src/js/admin/sections/SettingsFields/FormPreview/index.tsx
+++ b/src/js/admin/sections/SettingsFields/FormPreview/index.tsx
@@ -1,0 +1,55 @@
+import { useEffect, useRef, useState } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import { useSettingsFormContext } from '@admin/context/SettingsContext';
+import { PreviewCard, PreviewHeader, PreviewSelect, PreviewIframe } from './styled';
+import { PREVIEW_UPDATE_EVENT } from './consts';
+
+export default function FormPreview() {
+	const { formState } = useSettingsFormContext();
+	const iframeRef = useRef<HTMLIFrameElement>(null);
+	const petitions = window.petitionerData?.petitions || [];
+	const [selectedFormId, setSelectedFormId] = useState(petitions.length > 0 ? petitions[0].id : 0);
+
+	// Sync settings to the iframe via postMessage
+	useEffect(() => {
+		if (iframeRef.current && iframeRef.current.contentWindow) {
+			iframeRef.current.contentWindow.postMessage(
+				{ type: PREVIEW_UPDATE_EVENT, payload: formState },
+				'*'
+			);
+		}
+	}, [formState]);
+
+	const previewUrl = `${ajaxurl}?action=petitioner_live_preview&form_id=${selectedFormId}`;
+
+	return (
+		<PreviewCard>
+			<PreviewHeader>
+				<span>{__('Live Preview', 'petitioner')}</span>
+				{petitions.length > 0 && (
+					<PreviewSelect 
+						value={selectedFormId} 
+						onChange={(e) => setSelectedFormId(Number(e.target.value))}
+					>
+						{petitions.map((p) => (
+							<option key={p.id} value={p.id}>{p.title}</option>
+						))}
+					</PreviewSelect>
+				)}
+			</PreviewHeader>
+			<PreviewIframe 
+				ref={iframeRef}
+				src={previewUrl} 
+				onLoad={() => {
+					// Trigger initial sync once iframe loads
+					if (iframeRef.current?.contentWindow) {
+						iframeRef.current.contentWindow.postMessage(
+							{ type: PREVIEW_UPDATE_EVENT, payload: formState },
+							'*'
+						);
+					}
+				}}
+			/>
+		</PreviewCard>
+	);
+}

--- a/src/js/admin/sections/SettingsFields/FormPreview/index.tsx
+++ b/src/js/admin/sections/SettingsFields/FormPreview/index.tsx
@@ -8,6 +8,7 @@ import { PreviewCard, PreviewHeader, PreviewSelect, PreviewIframe } from './styl
 export default function FormPreview() {
 	const { formState } = useSettingsFormContext();
 	const iframeRef = useRef<HTMLIFrameElement>(null);
+	const abortControllerRef = useRef<AbortController | null>(null);
 	const [iframeLoaded, setIframeLoaded] = useState(false);
 
 	const petitions = useSelect((select) => {
@@ -39,9 +40,16 @@ export default function FormPreview() {
 			targetOrigin
 		);
 
+		// Cancel any pending CSS generation requests
+		if (abortControllerRef.current) {
+			abortControllerRef.current.abort();
+		}
+		abortControllerRef.current = new AbortController();
+
 		// 2. Fetch compiled CSS via AJAX
 		fetchPreviewCSS({
 			formState,
+			abortSignal: abortControllerRef.current.signal,
 			onSuccess: (css) => {
 				iframeRef.current?.contentWindow?.postMessage(
 					{ type: 'UPDATE_CSS', payload: css },

--- a/src/js/admin/sections/SettingsFields/FormPreview/index.tsx
+++ b/src/js/admin/sections/SettingsFields/FormPreview/index.tsx
@@ -28,10 +28,15 @@ export default function FormPreview() {
 	const syncPreview = useCallback(async () => {
 		if (!iframeRef.current?.contentWindow) return;
 
+		const targetOrigin = new URL(
+			window.petitionerData?.home_url || '/',
+			window.location.href
+		).origin;
+
 		// 1. Send visibility updates instantly
 		iframeRef.current.contentWindow.postMessage(
 			{ type: 'UPDATE_VISIBILITY', payload: formState },
-			'*'
+			targetOrigin
 		);
 
 		// 2. Fetch compiled CSS via AJAX
@@ -40,7 +45,7 @@ export default function FormPreview() {
 			onSuccess: (css) => {
 				iframeRef.current?.contentWindow?.postMessage(
 					{ type: 'UPDATE_CSS', payload: css },
-					'*'
+					targetOrigin
 				);
 			},
 			onError: (msg) => {

--- a/src/js/admin/sections/SettingsFields/FormPreview/index.tsx
+++ b/src/js/admin/sections/SettingsFields/FormPreview/index.tsx
@@ -1,9 +1,6 @@
-import { useEffect, useRef, useState, useCallback } from '@wordpress/element';
-import { useSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
-import { useSettingsFormContext } from '@admin/context/SettingsContext';
-import { fetchPreviewCSS } from './utilities';
 import { PreviewCard, PreviewHeader, PreviewSelect, PreviewIframe } from './styled';
+import { useFormPreview } from './hooks'
 
 interface PetitionRecord {
 	id: number;
@@ -13,83 +10,23 @@ interface PetitionRecord {
 }
 
 export default function FormPreview() {
-	const { formState } = useSettingsFormContext();
-	const iframeRef = useRef<HTMLIFrameElement>(null);
-	const abortControllerRef = useRef<AbortController | null>(null);
-	const [iframeLoaded, setIframeLoaded] = useState(false);
-
-	const petitions = useSelect((select) => {
-		// @ts-ignore - core-data types might not be fully available
-		return select('core').getEntityRecords('postType', 'petitioner-petition', {
-			per_page: -1,
-		});
-	}, []);
-
-	const [selectedFormId, setSelectedFormId] = useState(0);
-
-	useEffect(() => {
-		if (Array.isArray(petitions) && petitions.length > 0 && selectedFormId === 0) {
-			setSelectedFormId(petitions[0].id);
-		}
-	}, [petitions, selectedFormId]);
-
-	const syncPreview = useCallback(async () => {
-		if (!iframeRef.current?.contentWindow) return;
-
-		const targetOrigin = new URL(
-			window.petitionerData?.home_url || '/',
-			window.location.href
-		).origin;
-
-		// 1. Send visibility updates instantly
-		iframeRef.current.contentWindow.postMessage(
-			{ type: 'UPDATE_VISIBILITY', payload: formState },
-			targetOrigin
-		);
-
-		// Cancel any pending CSS generation requests
-		if (abortControllerRef.current) {
-			abortControllerRef.current.abort();
-		}
-		abortControllerRef.current = new AbortController();
-
-		// 2. Fetch compiled CSS via AJAX
-		fetchPreviewCSS({
-			formState,
-			abortSignal: abortControllerRef.current.signal,
-			onSuccess: (css) => {
-				iframeRef.current?.contentWindow?.postMessage(
-					{ type: 'UPDATE_CSS', payload: css },
-					targetOrigin
-				);
-			},
-			onError: (msg) => {
-				console.error(msg);
-			},
-		});
-	}, [formState]);
-
-	// Sync settings to the iframe via AJAX + postMessage
-	useEffect(() => {
-		if (!iframeLoaded) return;
-
-		// Debounce the AJAX call
-		const timeout = setTimeout(() => {
-			syncPreview();
-		}, 300);
-
-		return () => clearTimeout(timeout);
-	}, [syncPreview, iframeLoaded]);
-
-	const previewUrl = `${window.petitionerData?.home_url || '/'}?petitioner_live_preview=1&form_id=${selectedFormId}`;
+	const {
+		iframeRef,
+		previewUrl,
+		selectedFormId,
+		petitions,
+		setIframeLoaded,
+		setSelectedFormId,
+		syncPreview,
+	} = useFormPreview();
 
 	return (
 		<PreviewCard>
 			<PreviewHeader>
 				<span>{__('Live Preview', 'petitioner')}</span>
 				{Array.isArray(petitions) && petitions.length > 0 && (
-					<PreviewSelect 
-						value={selectedFormId} 
+					<PreviewSelect
+						value={selectedFormId}
 						onChange={(e) => {
 							setIframeLoaded(false);
 							setSelectedFormId(Number(e.target.value));
@@ -101,9 +38,9 @@ export default function FormPreview() {
 					</PreviewSelect>
 				)}
 			</PreviewHeader>
-			<PreviewIframe 
+			<PreviewIframe
 				ref={iframeRef}
-				src={previewUrl} 
+				src={previewUrl}
 				onLoad={() => {
 					setIframeLoaded(true);
 					syncPreview();

--- a/src/js/admin/sections/SettingsFields/FormPreview/index.tsx
+++ b/src/js/admin/sections/SettingsFields/FormPreview/index.tsx
@@ -20,7 +20,7 @@ export default function FormPreview() {
 	const [selectedFormId, setSelectedFormId] = useState(0);
 
 	useEffect(() => {
-		if (petitions && petitions.length > 0 && selectedFormId === 0) {
+		if (Array.isArray(petitions) && petitions.length > 0 && selectedFormId === 0) {
 			setSelectedFormId(petitions[0].id);
 		}
 	}, [petitions, selectedFormId]);
@@ -72,7 +72,7 @@ export default function FormPreview() {
 		<PreviewCard>
 			<PreviewHeader>
 				<span>{__('Live Preview', 'petitioner')}</span>
-				{petitions && petitions.length > 0 && (
+				{Array.isArray(petitions) && petitions.length > 0 && (
 					<PreviewSelect 
 						value={selectedFormId} 
 						onChange={(e) => {

--- a/src/js/admin/sections/SettingsFields/FormPreview/index.tsx
+++ b/src/js/admin/sections/SettingsFields/FormPreview/index.tsx
@@ -1,15 +1,14 @@
 import { useEffect, useRef, useState, useCallback } from '@wordpress/element';
 import { useSelect } from '@wordpress/data';
-import { Spinner } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { useSettingsFormContext } from '@admin/context/SettingsContext';
+import { getAjaxNonce } from '@admin/utilities';
 import { PreviewCard, PreviewHeader, PreviewSelect, PreviewIframe } from './styled';
 
 export default function FormPreview() {
 	const { formState } = useSettingsFormContext();
 	const iframeRef = useRef<HTMLIFrameElement>(null);
 	const [iframeLoaded, setIframeLoaded] = useState(false);
-	const [isSyncing, setIsSyncing] = useState(false);
 
 	const petitions = useSelect((select) => {
 		// @ts-ignore - core-data types might not be fully available
@@ -35,27 +34,31 @@ export default function FormPreview() {
 			'*'
 		);
 
-		setIsSyncing(true);
-
 		// 2. Fetch compiled CSS via AJAX
 		try {
-			const formData = new URLSearchParams();
-			formData.append('action', 'petitioner_generate_preview_css');
+			const finalQuery = new URLSearchParams();
+			finalQuery.set('action', 'petitioner_generate_preview_css');
+
+			const finalData = new FormData();
 			// serialize formState as payload
 			Object.entries(formState).forEach(([key, value]) => {
 				if (value !== undefined && value !== null) {
-					formData.append(`payload[${key}]`, String(value));
+					finalData.append(`payload[${key}]`, String(value));
 				}
 			});
+			finalData.append('petitioner_nonce', getAjaxNonce());
 
-			const response = await fetch(ajaxurl, {
+			const request = await fetch(`${ajaxurl}?${finalQuery.toString()}`, {
 				method: 'POST',
-				body: formData,
-				headers: {
-					'Content-Type': 'application/x-www-form-urlencoded',
-				},
+				body: finalData,
 			});
-			const result = await response.json();
+			
+			if (!request.ok) {
+				console.error('HTTP error: ', request.status);
+				return;
+			}
+			
+			const result = await request.json();
 
 			if (result.success && result.data?.css) {
 				iframeRef.current.contentWindow.postMessage(
@@ -65,8 +68,6 @@ export default function FormPreview() {
 			}
 		} catch (e) {
 			console.error('Failed to update live preview CSS', e);
-		} finally {
-			setIsSyncing(false);
 		}
 	}, [formState]);
 
@@ -87,10 +88,7 @@ export default function FormPreview() {
 	return (
 		<PreviewCard>
 			<PreviewHeader>
-				<span style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
-					{__('Live Preview', 'petitioner')}
-					{(isSyncing || !iframeLoaded) && <Spinner />}
-				</span>
+				<span>{__('Live Preview', 'petitioner')}</span>
 				{petitions && petitions.length > 0 && (
 					<PreviewSelect 
 						value={selectedFormId} 

--- a/src/js/admin/sections/SettingsFields/FormPreview/index.tsx
+++ b/src/js/admin/sections/SettingsFields/FormPreview/index.tsx
@@ -1,13 +1,15 @@
-import { useEffect, useRef, useState } from '@wordpress/element';
+import { useEffect, useRef, useState, useCallback } from '@wordpress/element';
 import { useSelect } from '@wordpress/data';
+import { Spinner } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { useSettingsFormContext } from '@admin/context/SettingsContext';
 import { PreviewCard, PreviewHeader, PreviewSelect, PreviewIframe } from './styled';
-import { PREVIEW_UPDATE_EVENT } from './consts';
 
 export default function FormPreview() {
 	const { formState } = useSettingsFormContext();
 	const iframeRef = useRef<HTMLIFrameElement>(null);
+	const [iframeLoaded, setIframeLoaded] = useState(false);
+	const [isSyncing, setIsSyncing] = useState(false);
 
 	const petitions = useSelect((select) => {
 		// @ts-ignore - core-data types might not be fully available
@@ -24,26 +26,78 @@ export default function FormPreview() {
 		}
 	}, [petitions, selectedFormId]);
 
-	// Sync settings to the iframe via postMessage
-	useEffect(() => {
-		if (iframeRef.current && iframeRef.current.contentWindow) {
-			iframeRef.current.contentWindow.postMessage(
-				{ type: PREVIEW_UPDATE_EVENT, payload: formState },
-				'*'
-			);
+	const syncPreview = useCallback(async () => {
+		if (!iframeRef.current?.contentWindow) return;
+
+		// 1. Send visibility updates instantly
+		iframeRef.current.contentWindow.postMessage(
+			{ type: 'UPDATE_VISIBILITY', payload: formState },
+			'*'
+		);
+
+		setIsSyncing(true);
+
+		// 2. Fetch compiled CSS via AJAX
+		try {
+			const formData = new URLSearchParams();
+			formData.append('action', 'petitioner_generate_preview_css');
+			// serialize formState as payload
+			Object.entries(formState).forEach(([key, value]) => {
+				if (value !== undefined && value !== null) {
+					formData.append(`payload[${key}]`, String(value));
+				}
+			});
+
+			const response = await fetch(ajaxurl, {
+				method: 'POST',
+				body: formData,
+				headers: {
+					'Content-Type': 'application/x-www-form-urlencoded',
+				},
+			});
+			const result = await response.json();
+
+			if (result.success && result.data?.css) {
+				iframeRef.current.contentWindow.postMessage(
+					{ type: 'UPDATE_CSS', payload: result.data.css },
+					'*'
+				);
+			}
+		} catch (e) {
+			console.error('Failed to update live preview CSS', e);
+		} finally {
+			setIsSyncing(false);
 		}
 	}, [formState]);
+
+	// Sync settings to the iframe via AJAX + postMessage
+	useEffect(() => {
+		if (!iframeLoaded) return;
+
+		// Debounce the AJAX call
+		const timeout = setTimeout(() => {
+			syncPreview();
+		}, 300);
+
+		return () => clearTimeout(timeout);
+	}, [syncPreview, iframeLoaded]);
 
 	const previewUrl = `${window.petitionerData?.home_url || '/'}?petitioner_live_preview=1&form_id=${selectedFormId}`;
 
 	return (
 		<PreviewCard>
 			<PreviewHeader>
-				<span>{__('Live Preview', 'petitioner')}</span>
+				<span style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
+					{__('Live Preview', 'petitioner')}
+					{(isSyncing || !iframeLoaded) && <Spinner />}
+				</span>
 				{petitions && petitions.length > 0 && (
 					<PreviewSelect 
 						value={selectedFormId} 
-						onChange={(e) => setSelectedFormId(Number(e.target.value))}
+						onChange={(e) => {
+							setIframeLoaded(false);
+							setSelectedFormId(Number(e.target.value));
+						}}
 					>
 						{petitions.map((p: any) => (
 							<option key={p.id} value={p.id}>{p.title?.rendered || __('(No Title)', 'petitioner')}</option>
@@ -55,13 +109,8 @@ export default function FormPreview() {
 				ref={iframeRef}
 				src={previewUrl} 
 				onLoad={() => {
-					// Trigger initial sync once iframe loads
-					if (iframeRef.current?.contentWindow) {
-						iframeRef.current.contentWindow.postMessage(
-							{ type: PREVIEW_UPDATE_EVENT, payload: formState },
-							'*'
-						);
-					}
+					setIframeLoaded(true);
+					syncPreview();
 				}}
 			/>
 		</PreviewCard>

--- a/src/js/admin/sections/SettingsFields/FormPreview/index.tsx
+++ b/src/js/admin/sections/SettingsFields/FormPreview/index.tsx
@@ -5,6 +5,13 @@ import { useSettingsFormContext } from '@admin/context/SettingsContext';
 import { fetchPreviewCSS } from './utilities';
 import { PreviewCard, PreviewHeader, PreviewSelect, PreviewIframe } from './styled';
 
+interface PetitionRecord {
+	id: number;
+	title?: {
+		rendered: string;
+	};
+}
+
 export default function FormPreview() {
 	const { formState } = useSettingsFormContext();
 	const iframeRef = useRef<HTMLIFrameElement>(null);
@@ -14,7 +21,7 @@ export default function FormPreview() {
 	const petitions = useSelect((select) => {
 		// @ts-ignore - core-data types might not be fully available
 		return select('core').getEntityRecords('postType', 'petitioner-petition', {
-			per_page: 10,
+			per_page: -1,
 		});
 	}, []);
 
@@ -88,7 +95,7 @@ export default function FormPreview() {
 							setSelectedFormId(Number(e.target.value));
 						}}
 					>
-						{petitions.map((p: any) => (
+						{petitions.map((p: PetitionRecord) => (
 							<option key={p.id} value={p.id}>{p.title?.rendered || __('(No Title)', 'petitioner')}</option>
 						))}
 					</PreviewSelect>

--- a/src/js/admin/sections/SettingsFields/FormPreview/index.tsx
+++ b/src/js/admin/sections/SettingsFields/FormPreview/index.tsx
@@ -34,7 +34,7 @@ export default function FormPreview() {
 		}
 	}, [formState]);
 
-	const previewUrl = `${ajaxurl}?action=petitioner_live_preview&form_id=${selectedFormId}`;
+	const previewUrl = `${window.petitionerData?.home_url || '/'}?petitioner_live_preview=1&form_id=${selectedFormId}`;
 
 	return (
 		<PreviewCard>

--- a/src/js/admin/sections/SettingsFields/FormPreview/index.tsx
+++ b/src/js/admin/sections/SettingsFields/FormPreview/index.tsx
@@ -1,5 +1,5 @@
 import { __ } from '@wordpress/i18n';
-import { PreviewCard, PreviewHeader, PreviewSelect, PreviewIframe } from './styled';
+import { PreviewCard, PreviewHeader, PreviewSelect, PreviewIframe, PreviewTitleWrapper } from './styled';
 import { useFormPreview } from './hooks'
 
 interface PetitionRecord {
@@ -16,20 +16,22 @@ export default function FormPreview() {
 		selectedFormId,
 		petitions,
 		setIframeLoaded,
-		setSelectedFormId,
+		onFormSelect,
 		syncPreview,
 	} = useFormPreview();
 
 	return (
 		<PreviewCard>
 			<PreviewHeader>
-				<span>{__('Live Preview', 'petitioner')}</span>
+				<PreviewTitleWrapper>
+					<p>{__('Live Preview', 'petitioner')}</p>
+					<small>{__('Note: this is not a perfect representation of your frontend, but its close', 'petitioner')}</small>
+				</PreviewTitleWrapper>
 				{Array.isArray(petitions) && petitions.length > 0 && (
 					<PreviewSelect
 						value={selectedFormId}
 						onChange={(e) => {
-							setIframeLoaded(false);
-							setSelectedFormId(Number(e.target.value));
+							onFormSelect(Number(e.target.value));
 						}}
 					>
 						{petitions.map((p: PetitionRecord) => (

--- a/src/js/admin/sections/SettingsFields/FormPreview/index.tsx
+++ b/src/js/admin/sections/SettingsFields/FormPreview/index.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState } from '@wordpress/element';
+import { useSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import { useSettingsFormContext } from '@admin/context/SettingsContext';
 import { PreviewCard, PreviewHeader, PreviewSelect, PreviewIframe } from './styled';
@@ -7,8 +8,21 @@ import { PREVIEW_UPDATE_EVENT } from './consts';
 export default function FormPreview() {
 	const { formState } = useSettingsFormContext();
 	const iframeRef = useRef<HTMLIFrameElement>(null);
-	const petitions = window.petitionerData?.petitions || [];
-	const [selectedFormId, setSelectedFormId] = useState(petitions.length > 0 ? petitions[0].id : 0);
+
+	const petitions = useSelect((select) => {
+		// @ts-ignore - core-data types might not be fully available
+		return select('core').getEntityRecords('postType', 'petitioner-petition', {
+			per_page: 10,
+		});
+	}, []);
+
+	const [selectedFormId, setSelectedFormId] = useState(0);
+
+	useEffect(() => {
+		if (petitions && petitions.length > 0 && selectedFormId === 0) {
+			setSelectedFormId(petitions[0].id);
+		}
+	}, [petitions, selectedFormId]);
 
 	// Sync settings to the iframe via postMessage
 	useEffect(() => {
@@ -26,13 +40,13 @@ export default function FormPreview() {
 		<PreviewCard>
 			<PreviewHeader>
 				<span>{__('Live Preview', 'petitioner')}</span>
-				{petitions.length > 0 && (
+				{petitions && petitions.length > 0 && (
 					<PreviewSelect 
 						value={selectedFormId} 
 						onChange={(e) => setSelectedFormId(Number(e.target.value))}
 					>
-						{petitions.map((p) => (
-							<option key={p.id} value={p.id}>{p.title}</option>
+						{petitions.map((p: any) => (
+							<option key={p.id} value={p.id}>{p.title?.rendered || __('(No Title)', 'petitioner')}</option>
 						))}
 					</PreviewSelect>
 				)}

--- a/src/js/admin/sections/SettingsFields/FormPreview/index.tsx
+++ b/src/js/admin/sections/SettingsFields/FormPreview/index.tsx
@@ -2,7 +2,7 @@ import { useEffect, useRef, useState, useCallback } from '@wordpress/element';
 import { useSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import { useSettingsFormContext } from '@admin/context/SettingsContext';
-import { getAjaxNonce } from '@admin/utilities';
+import { fetchPreviewCSS } from './utilities';
 import { PreviewCard, PreviewHeader, PreviewSelect, PreviewIframe } from './styled';
 
 export default function FormPreview() {
@@ -35,40 +35,18 @@ export default function FormPreview() {
 		);
 
 		// 2. Fetch compiled CSS via AJAX
-		try {
-			const finalQuery = new URLSearchParams();
-			finalQuery.set('action', 'petitioner_generate_preview_css');
-
-			const finalData = new FormData();
-			// serialize formState as payload
-			Object.entries(formState).forEach(([key, value]) => {
-				if (value !== undefined && value !== null) {
-					finalData.append(`payload[${key}]`, String(value));
-				}
-			});
-			finalData.append('petitioner_nonce', getAjaxNonce());
-
-			const request = await fetch(`${ajaxurl}?${finalQuery.toString()}`, {
-				method: 'POST',
-				body: finalData,
-			});
-			
-			if (!request.ok) {
-				console.error('HTTP error: ', request.status);
-				return;
-			}
-			
-			const result = await request.json();
-
-			if (result.success && result.data?.css) {
-				iframeRef.current.contentWindow.postMessage(
-					{ type: 'UPDATE_CSS', payload: result.data.css },
+		fetchPreviewCSS({
+			formState,
+			onSuccess: (css) => {
+				iframeRef.current?.contentWindow?.postMessage(
+					{ type: 'UPDATE_CSS', payload: css },
 					'*'
 				);
-			}
-		} catch (e) {
-			console.error('Failed to update live preview CSS', e);
-		}
+			},
+			onError: (msg) => {
+				console.error(msg);
+			},
+		});
 	}, [formState]);
 
 	// Sync settings to the iframe via AJAX + postMessage

--- a/src/js/admin/sections/SettingsFields/FormPreview/styled.tsx
+++ b/src/js/admin/sections/SettingsFields/FormPreview/styled.tsx
@@ -24,7 +24,7 @@ export const PreviewSelect = styled.select`
 
 export const PreviewIframe = styled.iframe`
 	width: 100%;
-	height: 700px;
+	min-height: 800px;
 	border: none;
 	display: block;
 `;

--- a/src/js/admin/sections/SettingsFields/FormPreview/styled.tsx
+++ b/src/js/admin/sections/SettingsFields/FormPreview/styled.tsx
@@ -1,4 +1,4 @@
-import { SPACINGS, COLORS } from '@admin/theme';
+import { SPACINGS, COLORS, BREAKPOINTS } from '@admin/theme';
 import styled from 'styled-components';
 
 export const PreviewCard = styled.div`
@@ -6,6 +6,11 @@ export const PreviewCard = styled.div`
 	border-radius: var(--ptr-admin-wrapper-radius);
 	background: #fff;
 	overflow: hidden;
+	display: none;
+
+	@media (min-width: ${BREAKPOINTS.lg}px) {
+		display: block;
+	}
 `;
 
 export const PreviewHeader = styled.div`

--- a/src/js/admin/sections/SettingsFields/FormPreview/styled.tsx
+++ b/src/js/admin/sections/SettingsFields/FormPreview/styled.tsx
@@ -1,17 +1,16 @@
 import styled from 'styled-components';
 
 export const PreviewCard = styled.div`
-	border: 1px solid #ddd;
-	border-radius: 4px;
+	border: 1px solid var(--ptr-admin-color-grey);
+	border-radius: var(--ptr-admin-wrapper-radius);
 	background: #fff;
 	overflow: hidden;
-	box-shadow: 0 1px 3px rgba(0,0,0,0.05);
 `;
 
 export const PreviewHeader = styled.div`
-	padding: 10px 15px;
-	background: #f6f7f7;
-	border-bottom: 1px solid #ddd;
+	padding: var(--ptr-admin-spacing-md) var(--ptr-admin-spacing-lg);
+	background: var(--ptr-admin-color-light);
+	border-bottom: 1px solid var(--ptr-admin-color-grey);
 	font-weight: 600;
 	display: flex;
 	justify-content: space-between;

--- a/src/js/admin/sections/SettingsFields/FormPreview/styled.tsx
+++ b/src/js/admin/sections/SettingsFields/FormPreview/styled.tsx
@@ -1,20 +1,21 @@
+import { SPACINGS, COLORS } from '@admin/theme';
 import styled from 'styled-components';
 
 export const PreviewCard = styled.div`
-	border: 1px solid var(--ptr-admin-color-grey);
+	border: 1px solid ${COLORS.grey};
 	border-radius: var(--ptr-admin-wrapper-radius);
 	background: #fff;
 	overflow: hidden;
 `;
 
 export const PreviewHeader = styled.div`
-	padding: var(--ptr-admin-spacing-md) var(--ptr-admin-spacing-lg);
-	background: var(--ptr-admin-color-light);
-	border-bottom: 1px solid var(--ptr-admin-color-grey);
+	padding: ${SPACINGS.md} ${SPACINGS.lg};
+	background: ${COLORS.light};
+	border-bottom: 1px solid ${COLORS.grey};
 	font-weight: 600;
 	display: flex;
 	justify-content: space-between;
-	align-items: center;
+	align-items: flex-end;
 `;
 
 export const PreviewSelect = styled.select`
@@ -27,4 +28,11 @@ export const PreviewIframe = styled.iframe`
 	min-height: 800px;
 	border: none;
 	display: block;
+`;
+
+export const PreviewTitleWrapper = styled.div`
+	display: flex;
+	flex-direction: column;
+	gap: 0;
+	color: ${COLORS.dark};
 `;

--- a/src/js/admin/sections/SettingsFields/FormPreview/styled.tsx
+++ b/src/js/admin/sections/SettingsFields/FormPreview/styled.tsx
@@ -1,0 +1,31 @@
+import styled from 'styled-components';
+
+export const PreviewCard = styled.div`
+	border: 1px solid #ddd;
+	border-radius: 4px;
+	background: #fff;
+	overflow: hidden;
+	box-shadow: 0 1px 3px rgba(0,0,0,0.05);
+`;
+
+export const PreviewHeader = styled.div`
+	padding: 10px 15px;
+	background: #f6f7f7;
+	border-bottom: 1px solid #ddd;
+	font-weight: 600;
+	display: flex;
+	justify-content: space-between;
+	align-items: center;
+`;
+
+export const PreviewSelect = styled.select`
+	max-width: 150px;
+	font-size: 13px;
+`;
+
+export const PreviewIframe = styled.iframe`
+	width: 100%;
+	height: 700px;
+	border: none;
+	display: block;
+`;

--- a/src/js/admin/sections/SettingsFields/FormPreview/utilities.ts
+++ b/src/js/admin/sections/SettingsFields/FormPreview/utilities.ts
@@ -1,4 +1,3 @@
-import { getAjaxNonce } from '@admin/utilities';
 import type { SettingsFormData } from '@admin/sections/SettingsFields/consts';
 
 interface FetchPreviewCSSSettings {
@@ -23,7 +22,7 @@ export const fetchPreviewCSS = async ({
 				finalData.append(`payload[${key}]`, String(value));
 			}
 		});
-		finalData.append('petitioner_nonce', getAjaxNonce());
+		finalData.append('petitioner_nonce', String(window.petitionerData.preview_nonce));
 
 		const request = await fetch(`${ajaxurl}?${finalQuery.toString()}`, {
 			method: 'POST',

--- a/src/js/admin/sections/SettingsFields/FormPreview/utilities.ts
+++ b/src/js/admin/sections/SettingsFields/FormPreview/utilities.ts
@@ -56,7 +56,3 @@ export const localGetSavedFormId = (): number | null => {
 export const localSaveFormID = (id: number) => {
 	window.localStorage.setItem(LOCAL_STORAGE_KEY, String(id));
 }
-
-export const localClearSavedFormID = () => {
-	window.localStorage.removeItem(LOCAL_STORAGE_KEY);
-}

--- a/src/js/admin/sections/SettingsFields/FormPreview/utilities.ts
+++ b/src/js/admin/sections/SettingsFields/FormPreview/utilities.ts
@@ -1,0 +1,48 @@
+import { getAjaxNonce } from '@admin/utilities';
+import type { SettingsFormData } from '@admin/sections/SettingsFields/consts';
+
+interface FetchPreviewCSSSettings {
+	formState: SettingsFormData;
+	onSuccess?: (css: string) => void;
+	onError?: (msg: string) => void;
+}
+
+export const fetchPreviewCSS = async ({
+	formState,
+	onSuccess = () => {},
+	onError = () => {},
+}: FetchPreviewCSSSettings) => {
+	try {
+		const finalQuery = new URLSearchParams();
+		finalQuery.set('action', 'petitioner_generate_preview_css');
+
+		const finalData = new FormData();
+		// serialize formState as payload
+		Object.entries(formState).forEach(([key, value]) => {
+			if (value !== undefined && value !== null) {
+				finalData.append(`payload[${key}]`, String(value));
+			}
+		});
+		finalData.append('petitioner_nonce', getAjaxNonce());
+
+		const request = await fetch(`${ajaxurl}?${finalQuery.toString()}`, {
+			method: 'POST',
+			body: finalData,
+		});
+
+		if (!request.ok) {
+			onError('HTTP error: ' + request.status);
+			return;
+		}
+
+		const result = await request.json();
+
+		if (result.success && result.data?.css) {
+			onSuccess(result.data.css);
+		} else {
+			onError('Failed to generate preview CSS');
+		}
+	} catch (error) {
+		onError('Error generating preview CSS: ' + error);
+	}
+};

--- a/src/js/admin/sections/SettingsFields/FormPreview/utilities.ts
+++ b/src/js/admin/sections/SettingsFields/FormPreview/utilities.ts
@@ -16,12 +16,7 @@ export const fetchPreviewCSS = async ({
 		finalQuery.set('action', 'petitioner_generate_preview_css');
 
 		const finalData = new FormData();
-		// serialize formState as payload
-		Object.entries(formState).forEach(([key, value]) => {
-			if (value !== undefined && value !== null) {
-				finalData.append(`payload[${key}]`, String(value));
-			}
-		});
+		finalData.append('payload', JSON.stringify(formState));
 		finalData.append('petitioner_nonce', String(window.petitionerData.preview_nonce));
 
 		const request = await fetch(`${ajaxurl}?${finalQuery.toString()}`, {

--- a/src/js/admin/sections/SettingsFields/FormPreview/utilities.ts
+++ b/src/js/admin/sections/SettingsFields/FormPreview/utilities.ts
@@ -4,12 +4,14 @@ interface FetchPreviewCSSSettings {
 	formState: SettingsFormData;
 	onSuccess?: (css: string) => void;
 	onError?: (msg: string) => void;
+	abortSignal?: AbortSignal;
 }
 
 export const fetchPreviewCSS = async ({
 	formState,
 	onSuccess = () => {},
 	onError = () => {},
+	abortSignal,
 }: FetchPreviewCSSSettings) => {
 	try {
 		const finalQuery = new URLSearchParams();
@@ -22,6 +24,7 @@ export const fetchPreviewCSS = async ({
 		const request = await fetch(`${ajaxurl}?${finalQuery.toString()}`, {
 			method: 'POST',
 			body: finalData,
+			signal: abortSignal,
 		});
 
 		if (!request.ok) {
@@ -37,6 +40,9 @@ export const fetchPreviewCSS = async ({
 			onError('Failed to generate preview CSS');
 		}
 	} catch (error) {
+		if (error instanceof DOMException && error.name === 'AbortError') {
+			return; // Silently ignore aborted requests
+		}
 		onError('Error generating preview CSS: ' + error);
 	}
 };

--- a/src/js/admin/sections/SettingsFields/FormPreview/utilities.ts
+++ b/src/js/admin/sections/SettingsFields/FormPreview/utilities.ts
@@ -1,4 +1,5 @@
 import type { SettingsFormData } from '@admin/sections/SettingsFields/consts';
+import { LOCAL_STORAGE_KEY } from './consts';
 
 interface FetchPreviewCSSSettings {
 	formState: SettingsFormData;
@@ -9,8 +10,8 @@ interface FetchPreviewCSSSettings {
 
 export const fetchPreviewCSS = async ({
 	formState,
-	onSuccess = () => {},
-	onError = () => {},
+	onSuccess = () => { },
+	onError = () => { },
 	abortSignal,
 }: FetchPreviewCSSSettings) => {
 	try {
@@ -46,3 +47,16 @@ export const fetchPreviewCSS = async ({
 		onError('Error generating preview CSS: ' + error);
 	}
 };
+
+export const localGetSavedFormId = (): number | null => {
+	const saved = window.localStorage.getItem(LOCAL_STORAGE_KEY);
+	return saved ? Number(saved) : null;
+}
+
+export const localSaveFormID = (id: number) => {
+	window.localStorage.setItem(LOCAL_STORAGE_KEY, String(id));
+}
+
+export const localClearSavedFormID = () => {
+	window.localStorage.removeItem(LOCAL_STORAGE_KEY);
+}

--- a/src/js/admin/sections/SettingsFields/VisualSettings.tsx
+++ b/src/js/admin/sections/SettingsFields/VisualSettings.tsx
@@ -4,7 +4,7 @@ import { useSettingsFormContext } from '@admin/context/SettingsContext';
 import { SelectControl } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import type { SettingsFormData } from './consts';
-import { VisualSettingsLayout, MainContent, SidebarContent } from './styled';
+import { VisualSettingsLayout, MainContent, SidebarContent, SizingGrid } from './styled';
 import FormPreview from './FormPreview';
 
 export default function VisualSettings({ isActive }: { isActive?: boolean }) {
@@ -17,7 +17,7 @@ export default function VisualSettings({ isActive }: { isActive?: boolean }) {
 	};
 
 	const visualOptions = windowPetitionerData?.default_values?.visual_options || {};
-	
+
 	const formatOptions = (optionsObj: Record<string, string> = {}) => {
 		return Object.entries(optionsObj || {}).map(([value, label]) => ({
 			label,
@@ -28,167 +28,170 @@ export default function VisualSettings({ isActive }: { isActive?: boolean }) {
 	return (
 		<VisualSettingsLayout>
 			<MainContent>
-			<p>
-				<input
-					checked={formState.show_letter}
-					type="checkbox"
-					name="petitioner_show_letter"
-					id="petitioner_show_letter"
-					className="widefat"
-					onChange={(e) => {
-						updateFormState('show_letter', e.target.checked);
-					}}
-				/>
-				<label htmlFor="petitioner_show_letter">
-					{__('Show letter on the frontend?', 'petitioner')}
-				</label>
-			</p>
-			<p>
-				<input
-					checked={formState.show_title}
-					type="checkbox"
-					name="petitioner_show_title"
-					id="petitioner_show_title"
-					className="widefat"
-					onChange={(e) => {
-						updateFormState('show_title', e.target.checked);
-					}}
-				/>
-				<label htmlFor="petitioner_show_title">
-					{__('Show petition title?', 'petitioner')}
-				</label>
-			</p>
-			<p>
-				<input
-					checked={formState.show_goal}
-					type="checkbox"
-					name="petitioner_show_goal"
-					id="petitioner_show_goal"
-					className="widefat"
-					onChange={(e) => {
-						updateFormState('show_goal', e.target.checked);
-					}}
-				/>
-				<label htmlFor="petitioner_show_goal">
-					{__('Show petition goal?', 'petitioner')}
-				</label>
-			</p>
+				<p>
+					<input
+						checked={formState.show_letter}
+						type="checkbox"
+						name="petitioner_show_letter"
+						id="petitioner_show_letter"
+						className="widefat"
+						onChange={(e) => {
+							updateFormState('show_letter', e.target.checked);
+						}}
+					/>
+					<label htmlFor="petitioner_show_letter">
+						{__('Show letter on the frontend?', 'petitioner')}
+					</label>
+				</p>
+				<p>
+					<input
+						checked={formState.show_title}
+						type="checkbox"
+						name="petitioner_show_title"
+						id="petitioner_show_title"
+						className="widefat"
+						onChange={(e) => {
+							updateFormState('show_title', e.target.checked);
+						}}
+					/>
+					<label htmlFor="petitioner_show_title">
+						{__('Show petition title?', 'petitioner')}
+					</label>
+				</p>
+				<p>
+					<input
+						checked={formState.show_goal}
+						type="checkbox"
+						name="petitioner_show_goal"
+						id="petitioner_show_goal"
+						className="widefat"
+						onChange={(e) => {
+							updateFormState('show_goal', e.target.checked);
+						}}
+					/>
+					<label htmlFor="petitioner_show_goal">
+						{__('Show petition goal?', 'petitioner')}
+					</label>
+				</p>
 
-			<hr />
+				<hr />
 
-			<h3 style={{ marginBottom: '0' }}>{__('Colors', 'petitioner')}</h3>
-			<div className="ptr-field-panel">
-				<div>
-					<label>{__('Primary color', 'petitioner')}</label>
+				<h3 style={{ marginBottom: '0' }}>{__('Colors', 'petitioner')}</h3>
+				<div className="ptr-field-panel">
+					<div>
+						<label>{__('Primary color', 'petitioner')}</label>
+					</div>
+					<ColorField
+						id={'petitioner_primary_color'}
+						color={formState?.primary_color}
+						defaultColor={defaultColors?.primary}
+						onColorChange={(newColor: string) =>
+							updateFormState('primary_color', newColor)
+						}
+					/>
 				</div>
-				<ColorField
-					id={'petitioner_primary_color'}
-					color={formState?.primary_color}
-					defaultColor={defaultColors?.primary}
-					onColorChange={(newColor: string) =>
-						updateFormState('primary_color', newColor)
-					}
-				/>
-			</div>
 
-			<div className="ptr-field-panel">
-				<div>
-					<label>{__('Dark color', 'petitioner')}</label>
+				<div className="ptr-field-panel">
+					<div>
+						<label>{__('Dark color', 'petitioner')}</label>
+					</div>
+					<ColorField
+						id={'petitioner_dark_color'}
+						color={formState?.dark_color}
+						defaultColor={defaultColors?.dark}
+						onColorChange={(newColor: string) =>
+							updateFormState('dark_color', newColor)
+						}
+					/>
 				</div>
-				<ColorField
-					id={'petitioner_dark_color'}
-					color={formState?.dark_color}
-					defaultColor={defaultColors?.dark}
-					onColorChange={(newColor: string) =>
-						updateFormState('dark_color', newColor)
-					}
-				/>
-			</div>
 
-			<div className="ptr-field-panel">
-				<div>
-					<label>{__('Grey color', 'petitioner')}</label>
+				<div className="ptr-field-panel">
+					<div>
+						<label>{__('Grey color', 'petitioner')}</label>
+					</div>
+					<ColorField
+						id={'petitioner_grey_color'}
+						color={formState?.grey_color}
+						defaultColor={defaultColors?.grey}
+						onColorChange={(newColor: string) =>
+							updateFormState('grey_color', newColor)
+						}
+					/>
 				</div>
-				<ColorField
-					id={'petitioner_grey_color'}
-					color={formState?.grey_color}
-					defaultColor={defaultColors?.grey}
-					onColorChange={(newColor: string) =>
-						updateFormState('grey_color', newColor)
-					}
+
+				<hr />
+
+				<h3 style={{ marginBottom: '0' }}>{__('Layout & Sizing', 'petitioner')}</h3>
+				<SizingGrid>
+					<div className="ptr-field-panel">
+						<SelectControl
+							label={__('Border Radius', 'petitioner')}
+							value={formState?.border_radius || ''}
+							options={formatOptions(visualOptions.border_radius)}
+							onChange={(val) => updateFormState('border_radius', val as SettingsFormData['border_radius'])}
+						/>
+						<input type="hidden" name="petitioner_border_radius" value={formState?.border_radius || ''} />
+					</div>
+
+					<div className="ptr-field-panel">
+						<SelectControl
+							label={__('Form Font Size', 'petitioner')}
+							value={formState?.base_font_size || ''}
+							options={formatOptions(visualOptions.base_font_size)}
+							onChange={(val) => updateFormState('base_font_size', val as SettingsFormData['base_font_size'])}
+						/>
+						<input type="hidden" name="petitioner_base_font_size" value={formState?.base_font_size || ''} />
+					</div>
+
+					<div className="ptr-field-panel">
+						<SelectControl
+							label={__('Button Font Size', 'petitioner')}
+							value={formState?.button_font_size || ''}
+							options={formatOptions(visualOptions.button_font_size)}
+							onChange={(val) => updateFormState('button_font_size', val as SettingsFormData['button_font_size'])}
+						/>
+						<input type="hidden" name="petitioner_button_font_size" value={formState?.button_font_size || ''} />
+					</div>
+
+					<div className="ptr-field-panel">
+						<SelectControl
+							label={__('Input Border Thickness', 'petitioner')}
+							value={formState?.input_border_width || ''}
+							options={formatOptions(visualOptions.input_border_width)}
+							onChange={(val) => updateFormState('input_border_width', val as SettingsFormData['input_border_width'])}
+						/>
+						<input type="hidden" name="petitioner_input_border_width" value={formState?.input_border_width || ''} />
+					</div>
+
+					<div className="ptr-field-panel">
+						<SelectControl
+							label={__('Field Spacing', 'petitioner')}
+							value={formState?.field_spacing || ''}
+							options={formatOptions(visualOptions.field_spacing)}
+							onChange={(val) => updateFormState('field_spacing', val as SettingsFormData['field_spacing'])}
+						/>
+						<input type="hidden" name="petitioner_field_spacing" value={formState?.field_spacing || ''} />
+					</div>
+
+					<div className="ptr-field-panel">
+						<SelectControl
+							label={__('Input Size', 'petitioner')}
+							value={formState?.input_size || ''}
+							options={formatOptions(visualOptions.input_size)}
+							onChange={(val) => updateFormState('input_size', val as SettingsFormData['input_size'])}
+						/>
+						<input type="hidden" name="petitioner_input_size" value={formState?.input_size || ''} />
+					</div>
+
+				</SizingGrid>
+
+				<CodeEditor
+					code={formState?.custom_css || ''}
+					title={__('Custom CSS', 'petitioner')}
+					help={__('Add your custom CSS here.', 'petitioner')}
+					onChange={(val) => updateFormState('custom_css', val)}
+					isActive={isActive}
 				/>
-			</div>
-
-			<hr />
-
-			<h3 style={{ marginBottom: '0' }}>{__('Layout & Sizing', 'petitioner')}</h3>
-			<div className="ptr-field-panel">
-				<SelectControl
-					label={__('Border Radius', 'petitioner')}
-					value={formState?.border_radius || ''}
-					options={formatOptions(visualOptions.border_radius)}
-					onChange={(val) => updateFormState('border_radius', val as SettingsFormData['border_radius'])}
-				/>
-				<input type="hidden" name="petitioner_border_radius" value={formState?.border_radius || ''} />
-			</div>
-
-			<div className="ptr-field-panel">
-				<SelectControl
-					label={__('Form Font Size', 'petitioner')}
-					value={formState?.base_font_size || ''}
-					options={formatOptions(visualOptions.base_font_size)}
-					onChange={(val) => updateFormState('base_font_size', val as SettingsFormData['base_font_size'])}
-				/>
-				<input type="hidden" name="petitioner_base_font_size" value={formState?.base_font_size || ''} />
-			</div>
-
-			<div className="ptr-field-panel">
-				<SelectControl
-					label={__('Button Font Size', 'petitioner')}
-					value={formState?.button_font_size || ''}
-					options={formatOptions(visualOptions.button_font_size)}
-					onChange={(val) => updateFormState('button_font_size', val as SettingsFormData['button_font_size'])}
-				/>
-				<input type="hidden" name="petitioner_button_font_size" value={formState?.button_font_size || ''} />
-			</div>
-
-			<div className="ptr-field-panel">
-				<SelectControl
-					label={__('Input Border Thickness', 'petitioner')}
-					value={formState?.input_border_width || ''}
-					options={formatOptions(visualOptions.input_border_width)}
-					onChange={(val) => updateFormState('input_border_width', val as SettingsFormData['input_border_width'])}
-				/>
-				<input type="hidden" name="petitioner_input_border_width" value={formState?.input_border_width || ''} />
-			</div>
-
-			<div className="ptr-field-panel">
-				<SelectControl
-					label={__('Field Spacing', 'petitioner')}
-					value={formState?.field_spacing || ''}
-					options={formatOptions(visualOptions.field_spacing)}
-					onChange={(val) => updateFormState('field_spacing', val as SettingsFormData['field_spacing'])}
-				/>
-				<input type="hidden" name="petitioner_field_spacing" value={formState?.field_spacing || ''} />
-			</div>
-
-			<div className="ptr-field-panel">
-				<SelectControl
-					label={__('Input Size', 'petitioner')}
-					value={formState?.input_size || ''}
-					options={formatOptions(visualOptions.input_size)}
-					onChange={(val) => updateFormState('input_size', val as SettingsFormData['input_size'])}
-				/>
-				<input type="hidden" name="petitioner_input_size" value={formState?.input_size || ''} />
-			</div>
-
-			<CodeEditor
-				code={formState?.custom_css || ''}
-				title={__('Custom CSS', 'petitioner')}
-				help={__('Add your custom CSS here.', 'petitioner')}
-				onChange={(val) => updateFormState('custom_css', val)}
-				isActive={isActive}
-			/>
 			</MainContent>
 			<SidebarContent>
 				<FormPreview />

--- a/src/js/admin/sections/SettingsFields/VisualSettings.tsx
+++ b/src/js/admin/sections/SettingsFields/VisualSettings.tsx
@@ -4,6 +4,8 @@ import { useSettingsFormContext } from '@admin/context/SettingsContext';
 import { SelectControl } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import type { SettingsFormData } from './consts';
+import { VisualSettingsLayout, MainContent, SidebarContent } from './styled';
+import FormPreview from './FormPreview';
 
 export default function VisualSettings() {
 	const { formState, updateFormState, windowPetitionerData } = useSettingsFormContext();
@@ -24,7 +26,8 @@ export default function VisualSettings() {
 	};
 
 	return (
-		<>
+		<VisualSettingsLayout>
+			<MainContent>
 			<p>
 				<input
 					checked={formState.show_letter}
@@ -184,6 +187,10 @@ export default function VisualSettings() {
 				title={__('Custom CSS', 'petitioner')}
 				help={__('Add your custom CSS here.', 'petitioner')}
 			/>
-		</>
+			</MainContent>
+			<SidebarContent>
+				<FormPreview />
+			</SidebarContent>
+		</VisualSettingsLayout>
 	);
 }

--- a/src/js/admin/sections/SettingsFields/VisualSettings.tsx
+++ b/src/js/admin/sections/SettingsFields/VisualSettings.tsx
@@ -186,6 +186,7 @@ export default function VisualSettings() {
 				code={formState?.custom_css || ''}
 				title={__('Custom CSS', 'petitioner')}
 				help={__('Add your custom CSS here.', 'petitioner')}
+				onChange={(val) => updateFormState('custom_css', val)}
 			/>
 			</MainContent>
 			<SidebarContent>

--- a/src/js/admin/sections/SettingsFields/VisualSettings.tsx
+++ b/src/js/admin/sections/SettingsFields/VisualSettings.tsx
@@ -7,7 +7,7 @@ import type { SettingsFormData } from './consts';
 import { VisualSettingsLayout, MainContent, SidebarContent } from './styled';
 import FormPreview from './FormPreview';
 
-export default function VisualSettings() {
+export default function VisualSettings({ isActive }: { isActive?: boolean }) {
 	const { formState, updateFormState, windowPetitionerData } = useSettingsFormContext();
 
 	const defaultColors = windowPetitionerData?.default_values?.colors || {
@@ -187,6 +187,7 @@ export default function VisualSettings() {
 				title={__('Custom CSS', 'petitioner')}
 				help={__('Add your custom CSS here.', 'petitioner')}
 				onChange={(val) => updateFormState('custom_css', val)}
+				isActive={isActive}
 			/>
 			</MainContent>
 			<SidebarContent>

--- a/src/js/admin/sections/SettingsFields/consts.ts
+++ b/src/js/admin/sections/SettingsFields/consts.ts
@@ -40,6 +40,7 @@ export type DefaultValues = {
 
 export interface WindowSettingsData extends SettingsFormData {
 	default_values?: DefaultValues;
+	preview_nonce?: string;
 }
 
 export type SettingsFormContextValue = {

--- a/src/js/admin/sections/SettingsFields/index.tsx
+++ b/src/js/admin/sections/SettingsFields/index.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useRef } from '@wordpress/element';
 import { Dashicon } from '@wordpress/components';
 import Tabs from '@admin/components/Tabs';
 import VisualSettings from './VisualSettings';
@@ -48,10 +49,47 @@ const tabs = [
 function SettingsFieldsComponent() {
 	const { formState } = useSettingsFormContext();
 	const { active_tab } = formState;
+	const iframeRef = useRef<HTMLIFrameElement>(null);
+
+	// Sync settings to the iframe via postMessage
+	useEffect(() => {
+		if (iframeRef.current && iframeRef.current.contentWindow) {
+			iframeRef.current.contentWindow.postMessage(
+				{ type: 'UPDATE_SETTINGS', payload: formState },
+				'*'
+			);
+		}
+	}, [formState]);
+
+	const previewUrl = `${ajaxurl}?action=petitioner_live_preview`;
 
 	return (
-		<div className="petitioner-settings-box">
-			<Tabs tabs={tabs} updateURL={true} defaultTab={active_tab} />
+		<div className="petitioner-settings-box" style={{ display: 'flex', gap: '20px', alignItems: 'flex-start' }}>
+			<div style={{ flex: '1 1 60%', maxWidth: '800px' }}>
+				<Tabs tabs={tabs} updateURL={true} defaultTab={active_tab} />
+			</div>
+			
+			<div style={{ flex: '1 1 40%', minWidth: '400px', position: 'sticky', top: '40px' }}>
+				<div style={{ border: '1px solid #ddd', borderRadius: '4px', background: '#fff', overflow: 'hidden', boxShadow: '0 1px 3px rgba(0,0,0,0.05)' }}>
+					<div style={{ padding: '10px 15px', background: '#f6f7f7', borderBottom: '1px solid #ddd', fontWeight: 600 }}>
+						{__('Live Preview', 'petitioner')}
+					</div>
+					<iframe 
+						ref={iframeRef}
+						src={previewUrl} 
+						style={{ width: '100%', height: '700px', border: 'none', display: 'block' }}
+						onLoad={() => {
+							// Trigger initial sync once iframe loads
+							if (iframeRef.current?.contentWindow) {
+								iframeRef.current.contentWindow.postMessage(
+									{ type: 'UPDATE_SETTINGS', payload: formState },
+									'*'
+								);
+							}
+						}}
+					/>
+				</div>
+			</div>
 		</div>
 	);
 }

--- a/src/js/admin/sections/SettingsFields/index.tsx
+++ b/src/js/admin/sections/SettingsFields/index.tsx
@@ -1,4 +1,3 @@
-import { useEffect, useRef } from '@wordpress/element';
 import { Dashicon } from '@wordpress/components';
 import Tabs from '@admin/components/Tabs';
 import VisualSettings from './VisualSettings';
@@ -9,6 +8,7 @@ import {
 	useSettingsFormContext,
 } from '@admin/context/SettingsContext';
 import { __ } from '@wordpress/i18n';
+import { SettingsContainer } from './styled';
 
 const tabs = [
 	{
@@ -49,48 +49,11 @@ const tabs = [
 function SettingsFieldsComponent() {
 	const { formState } = useSettingsFormContext();
 	const { active_tab } = formState;
-	const iframeRef = useRef<HTMLIFrameElement>(null);
-
-	// Sync settings to the iframe via postMessage
-	useEffect(() => {
-		if (iframeRef.current && iframeRef.current.contentWindow) {
-			iframeRef.current.contentWindow.postMessage(
-				{ type: 'UPDATE_SETTINGS', payload: formState },
-				'*'
-			);
-		}
-	}, [formState]);
-
-	const previewUrl = `${ajaxurl}?action=petitioner_live_preview`;
 
 	return (
-		<div className="petitioner-settings-box" style={{ display: 'flex', gap: '20px', alignItems: 'flex-start' }}>
-			<div style={{ flex: '1 1 60%', maxWidth: '800px' }}>
-				<Tabs tabs={tabs} updateURL={true} defaultTab={active_tab} />
-			</div>
-			
-			<div style={{ flex: '1 1 40%', minWidth: '400px', position: 'sticky', top: '40px' }}>
-				<div style={{ border: '1px solid #ddd', borderRadius: '4px', background: '#fff', overflow: 'hidden', boxShadow: '0 1px 3px rgba(0,0,0,0.05)' }}>
-					<div style={{ padding: '10px 15px', background: '#f6f7f7', borderBottom: '1px solid #ddd', fontWeight: 600 }}>
-						{__('Live Preview', 'petitioner')}
-					</div>
-					<iframe 
-						ref={iframeRef}
-						src={previewUrl} 
-						style={{ width: '100%', height: '700px', border: 'none', display: 'block' }}
-						onLoad={() => {
-							// Trigger initial sync once iframe loads
-							if (iframeRef.current?.contentWindow) {
-								iframeRef.current.contentWindow.postMessage(
-									{ type: 'UPDATE_SETTINGS', payload: formState },
-									'*'
-								);
-							}
-						}}
-					/>
-				</div>
-			</div>
-		</div>
+		<SettingsContainer>
+			<Tabs tabs={tabs} updateURL={true} defaultTab={active_tab} />
+		</SettingsContainer>
 	);
 }
 

--- a/src/js/admin/sections/SettingsFields/styled.tsx
+++ b/src/js/admin/sections/SettingsFields/styled.tsx
@@ -1,4 +1,5 @@
 import styled from 'styled-components';
+import { SPACINGS, BREAKPOINTS } from '@admin/theme';
 
 export const SettingsContainer = styled.div.attrs({ className: 'petitioner-settings-box' })``;
 
@@ -19,3 +20,14 @@ export const SidebarContent = styled.div`
 	position: sticky;
 	top: 40px;
 `;
+
+export const SizingGrid = styled.div`
+	display: grid;
+	gap: ${SPACINGS.lg};
+	grid-template-columns: 1fr;
+	grid-auto-rows: min-content;
+
+	@media (min-width: ${BREAKPOINTS.xl}px) {
+		grid-template-columns: repeat(2, 250px);
+	}
+`

--- a/src/js/admin/sections/SettingsFields/styled.tsx
+++ b/src/js/admin/sections/SettingsFields/styled.tsx
@@ -10,24 +10,35 @@ export const VisualSettingsLayout = styled.div`
 `;
 
 export const MainContent = styled.div`
-	flex: 1 1 60%;
-	max-width: 800px;
+	@media (min-width: ${BREAKPOINTS.lg}px) {
+		flex: 1 1 60%;
+		max-width: 800px;
+	}
 `;
 
 export const SidebarContent = styled.div`
-	flex: 1 1 40%;
-	min-width: 400px;
-	position: sticky;
-	top: 40px;
+	display: none;
+
+	@media (min-width: ${BREAKPOINTS.xl}px) {
+		display: block;
+		flex: 1 1 40%;
+		min-width: 400px;
+		position: sticky;
+		top: 40px;
+	}
 `;
 
 export const SizingGrid = styled.div`
 	display: grid;
-	gap: ${SPACINGS.lg};
+	gap: ${SPACINGS['2xl']};
 	grid-template-columns: 1fr;
 	grid-auto-rows: min-content;
 
 	@media (min-width: ${BREAKPOINTS.xl}px) {
 		grid-template-columns: repeat(2, 250px);
+	}
+
+	.ptr-field-panel > * {
+		flex-grow: 1;
 	}
 `

--- a/src/js/admin/sections/SettingsFields/styled.tsx
+++ b/src/js/admin/sections/SettingsFields/styled.tsx
@@ -1,0 +1,21 @@
+import styled from 'styled-components';
+
+export const SettingsContainer = styled.div.attrs({ className: 'petitioner-settings-box' })``;
+
+export const VisualSettingsLayout = styled.div`
+	display: flex;
+	gap: 20px;
+	align-items: flex-start;
+`;
+
+export const MainContent = styled.div`
+	flex: 1 1 60%;
+	max-width: 800px;
+`;
+
+export const SidebarContent = styled.div`
+	flex: 1 1 40%;
+	min-width: 400px;
+	position: sticky;
+	top: 40px;
+`;


### PR DESCRIPTION
## Description of change

[Issue link](https://github.com/avoy18/petitioner/issues/114)

Adding a customizer live preview to the settings page. How it works:

- We have a custom route that renders the real form server side
- We load it via iframe and communicate the changes through postMessage
- Most of the logic uses server-side utils we use on the frontend, but some are handled via custom JS


<img width="1351" height="780" alt="image" src="https://github.com/user-attachments/assets/d931aa2f-8ccc-4aaa-9fc2-2c696002ec13" />

